### PR TITLE
10.0 [IMP] Display the CMIS widget in edit mode.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+10.0.?.?.? (?)
+~~~~~~~~~~~~~~
+
+* Improvement: Display the CMIS widget in edit mode. In some cases it's useful
+  to have access to the preview of one document when filling the html form to
+  copy/paste information from document into the form.
+
+
 10.0.1.0.0 (Jan, 4, 20016)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/cmis_web/static/src/js/form_widgets.js
+++ b/cmis_web/static/src/js/form_widgets.js
@@ -547,8 +547,8 @@ var CmisMixin = {
         if (this.$el.is(':visible')){
             this.render_datatable();
         }
-        if (this.field_manager.get("actual_mode") !== "view"){
-            // hide the widget in edit mode
+        if (!this.getParent().datarecord.id){
+            // hide the widget if the record is not yet created
             this.$el.hide();
         } else {
             this.$el.toggle(!this.invisible);
@@ -565,8 +565,8 @@ var CmisMixin = {
         if (this.$input) {
             this.$input.val(value);
         }
-        if (this.field_manager.get("actual_mode") !== "view"){
-            // hide the widget in edit mode
+        if (!this.getParent().datarecord.id){
+            // hide the widget if the record is not yet created
             this.$el.hide();
         }
         this.$el.find('button.cmis-create-root').addClass('hidden');


### PR DESCRIPTION
In some cases it's useful to have access to the preview of one document when filling the html form to copy/paste information from document into the form.

Forward port of #19