### PR TITLE
[9.0][FIX] s/_('Confirm deletion of ')/_t('Confirm deletion of ')

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 9.0.?.?.? (?)
 ~~~~~~~~~~~~~
 
+* Fix: Makes the delete confirmation message translatable.
 * Improvement: Add new method on the cmis_folder field to get a proxy object
   that let's you perform CMIS actions on the forlder into the CMIS container.
 * Improvement: Display the CMIS widget in edit mode. In some cases it's useful

--- a/cmis_web/static/src/js/form_widgets.js
+++ b/cmis_web/static/src/js/form_widgets.js
@@ -1051,7 +1051,7 @@ var CmisMixin = {
         var data = row.data();
         var self = this;
         Dialog.confirm(
-                self, _('Confirm deletion of ') + data.name ,
+                self, _t('Confirm deletion of ') + data.name ,
                 { confirm_callback: function(){
                     var all_versions = true;
                     self.cmis_session.deleteObject(data.objectId, all_versions).ok(function(){


### PR DESCRIPTION
a small typo fix to make `Confirm deletion of ` translatable