### PR TITLE
[9.0] [FIX] Redraw datatable widget on tab activate

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 9.0.?.?.? (?)
 ~~~~~~~~~~~~~
 
+* Fix: Redraw the datatable widget on tab activate
 * Fix: JS error into Firefox on create/update document
 * Fix: The document preview works also with IE.
 * Fix: Makes the file required into the update document dialog.

--- a/cmis_web/static/src/js/form_widgets.js
+++ b/cmis_web/static/src/js/form_widgets.js
@@ -761,6 +761,8 @@ var CmisMixin = {
             var config = this.get_datatable_config();
             this.datatable = this.$datatable.DataTable(config);
             this.table_rendered.resolve();
+        } else {
+            this.datatable.draw();
         }
     },
 


### PR DESCRIPTION
back port of #44 