### PR TITLE
[10.0-cmis_report_write-jne] cmis_report_write 

### DIFF
--- a/cmis_report_write/models/report.py
+++ b/cmis_report_write/models/report.py
@@ -19,16 +19,14 @@ class Report(models.Model):
 
     _inherit = 'report'
 
-    @api.v7
-    def get_pdf(self, cr, uid, ids, report_name, html=None, data=None,
-                context=None):
+    @api.model
+    def get_pdf(self, ids, report_name, html=None, data=None):
         """This method generates and returns pdf version of a report.
         """
         # put the report_name into the context to use it in method
         #  _save_in_attachment
-        ctx = dict(context or {}, report_name=report_name)
-        return super(Report, self).get_pdf(
-            cr, uid, ids, report_name, html, data, context=ctx)
+        self = self.with_context(report_name=report_name)
+        return super(Report, self).get_pdf(ids, report_name, html, data)
 
     @api.model
     def _postprocess_report(self, report_path, res_id, save_in_attachment):
@@ -126,7 +124,7 @@ class Report(models.Model):
         return mimetypes.guess_type(file_name)[0]
 
     def _sanitize_query_arg(self, arg):
-        return arg.replace("'", r"\'") 
+        return arg.replace("'", r"\'")
 
     @api.model
     def _create_or_update_cmis_document(self, content,

--- a/cmis_report_write/tests/test_cmis_report_write.py
+++ b/cmis_report_write/tests/test_cmis_report_write.py
@@ -42,8 +42,7 @@ class TestCmisReportWrite(common.BaseTestCmis):
         with mock.patch('openerp.addons.cmis_report_write.models.'
                         'report.Report._save_in_cmis') as mocked_save:
             # test the call the the create method inside our custom parser
-            self.registry['report'].get_pdf(
-                self.env.cr, self.env.uid, inst.ids, self.report_name)
+            self.env['report'].get_pdf(inst.ids, self.report_name)
             # check that the method is called
             self.assertEqual(mocked_save.call_count, 1)
             content, res_id, report_xml = mocked_save.call_args[0]
@@ -59,8 +58,7 @@ class TestCmisReportWrite(common.BaseTestCmis):
                         'report.Report.'
                         '_create_or_update_cmis_document') as mocked_save:
             # test the call the the create method inside our custom parser
-            self.registry['report'].get_pdf(
-                self.env.cr, self.env.uid, self.inst.ids, self.report_name)
+            self.env['report'].get_pdf(self.inst.ids, self.report_name)
             # check that the method is called
             self.assertEqual(mocked_save.call_count, 0)
 
@@ -83,16 +81,14 @@ class TestCmisReportWrite(common.BaseTestCmis):
             rp.query.return_value = rs
             rs.getNumItems.return_value = 0
             # test the call the the create method inside our custom parser
-            self.registry['report'].get_pdf(
-                self.env.cr, self.env.uid, self.inst.ids, self.report_name)
+            self.env['report'].get_pdf(self.inst.ids, self.report_name)
             # the first call must succeed
             self.assertEqual(mocked_create.call_count, 1)
 
             with self.assertRaises(UserError):
                 # a second call must fails
                 rs.getNumItems.return_value = 1
-                self.registry['report'].get_pdf(
-                    self.env.cr, self.env.uid, self.inst.ids, self.report_name)
+                self.env['report'].get_pdf(self.inst.ids, self.report_name)
 
     def test_duplicate_handle_new_version(self):
         self.report.cmis_duplicate_handler = 'new_version'
@@ -117,8 +113,7 @@ class TestCmisReportWrite(common.BaseTestCmis):
             rp.query.return_value = rs
             rs.getNumItems.return_value = 1
             # test the call the the create method inside our custom parser
-            self.registry['report'].get_pdf(
-                self.env.cr, self.env.uid, self.inst.ids, self.report_name)
+            self.env['report'].get_pdf(self.inst.ids, self.report_name)
             # the first call must succeed
             self.assertEqual(mocked_create.call_count, 0)
             self.assertEqual(mocked_update.call_count, 1)
@@ -145,8 +140,7 @@ class TestCmisReportWrite(common.BaseTestCmis):
             cmis_parent_folder.getChildren.return_value = rs
             rs.getNumItems.return_value = 1
             # test the call the the create method inside our custom parser
-            self.registry['report'].get_pdf(
-                self.env.cr, self.env.uid, self.inst.ids, self.report_name)
+            self.env['report'].get_pdf(self.inst.ids, self.report_name)
             # the first call must succeed
             self.assertEqual(mocked_create.call_count, 1)
             file_name = mocked_create.call_args[0][3]

--- a/cmis_web_alf/models/cmis_backend.py
+++ b/cmis_web_alf/models/cmis_backend.py
@@ -2,7 +2,8 @@
 # Copyright 2016 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from cmislib.browser.binding import safe_urlencode
+from cmislib.browser.binding import (  # pylint: disable=W7935,W7936
+    safe_urlencode)
 from odoo import api, models
 
 

--- a/cmis_web_report_write_alf/models/report.py
+++ b/cmis_web_report_write_alf/models/report.py
@@ -29,7 +29,7 @@ class Report(models.Model):
             root_objectId = record[field_name]
             url = cmis_backend.get_content_details_url(res)
             bus_message = {
-                'cmis_objectid':root_objectId,
+                'cmis_objectid': root_objectId,
                 'backend_id': cmis_backend.id,
                 'url': url,
                 'action': 'open_url',


### PR DESCRIPTION
This PR responds to #40.
With lasts version of Odoo, there is no way to render a PDF report.

This could possibly breaks the process chain so we should run complete test cases.