### PR TITLE
[9.0]  Handle  name conflict on folder create

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,75 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
 html
+
+# PyBuilder
+target/
+
+# virtualenv
+venv
+
+# editable sources
+/src/
+
+# release directory
+release
+
+# pydev
+.project
+.jshintrc
+.pydevproject
+.settings
+.idea
+

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,10 +6,21 @@
 * Fix: JS error when multiple documents are uploaded at once.
 
 
+9.?.?.?.? (?)
+~~~~~~~~~~~~~
+
+* Improvement: New document viewer.
+
+
 9.0.2.0.0 (Oct, 17, 2017)
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Improvement: New document viewer.
+* Improvement: Handle name conflict on folder create.
+  A new parameter on the backend let's you choice between 2 strategies:
+  'error' or 'increment. If a folder already exists with the same name, the
+  system will raise an error if 'error' is specified as strategy (default)
+  otherwise a suffix is added to the name to make it unique.
+>>>>>>> [IMP] Handle name conflict on folder create.
 * Improvement: Allow the preview of image files.
 * Fix: Display the node title if set into the CMIS container.
 * Fix: On the import document dialog, rename 'Create' button into 'Add'

--- a/cmis_field/fields/cmis_folder.py
+++ b/cmis_field/fields/cmis_folder.py
@@ -132,6 +132,7 @@ class CmisFolder(fields.Field):
             else:
                 backend.is_valid_cmis_name(name, raise_if_invalid=True)
             parent = parents[record.id]
+            name = backend.get_unique_folder_name(name, parent)
             props = properties[record.id] or {}
             value = repo.createFolder(
                 parent, name, props)

--- a/cmis_field/tests/common.py
+++ b/cmis_field/tests/common.py
@@ -29,3 +29,20 @@ class BaseTestCmis(common.SavepointCase):
         cls.cmis_test_model = cls._init_test_model(models.CmisTestModel)
         cls.cmis_backend = cls.env.ref('cmis.cmis_backend_alfresco')
         cls.cmis_backend.initial_directory_write = '/odoo'
+
+    def setUp(self):
+        super(BaseTestCmis, self).setUp()
+
+        # global patch
+
+        def get_unique_folder_name(name, parent):
+            return name
+        self.patched_get_unique_folder_name = mock.patch.object(
+            self.cmis_backend.__class__, 'get_unique_folder_name',
+            side_effect=get_unique_folder_name
+        )
+        self.patched_get_unique_folder_name.start()
+
+    def tearDown(self):
+        super(BaseTestCmis, self).tearDown()
+        self.patched_get_unique_folder_name.stop()

--- a/cmis_field/tests/test_cmis_backend.py
+++ b/cmis_field/tests/test_cmis_backend.py
@@ -3,6 +3,7 @@
 # Copyright 2016 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+import mock
 from openerp.tests import common
 from openerp.exceptions import UserError, ValidationError
 
@@ -59,3 +60,46 @@ class TestCmisBackend(common.SavepointCase):
         sanitized = self.backend_instance.sanitize_cmis_names(
             ['/y dir*', 'sub/dir'], ' ')
         self.assertEqual(sanitized, ['y dir', 'sub dir'])
+
+    def test_get_unique_folder_name(self):
+        mocked_parent = mock.MagicMock()
+        # if no name found, the method return the same name
+        repository = mock.MagicMock()
+        mocked_parent.repository = repository
+        query_result = mock.MagicMock()
+        repository.query.side_effect = lambda *a: query_result
+        query_result.getNumItems.side_effect = lambda *a: 0
+        self.assertEqual('test', self.backend_instance.get_unique_folder_name(
+            'test', mocked_parent))
+        # if the same name is found and the folder_name_conflict_handler ==
+        # 'error' a ValidationError is raised
+        query_result.getNumItems.side_effect = lambda *a: 1
+        self.backend_instance.folder_name_conflict_handler = 'error'
+        with self.assertRaises(ValidationError):
+            self.backend_instance.get_unique_folder_name('test', mocked_parent)
+
+        self.cpt = 0
+
+        def query(q):
+            if self.cpt == 0:
+                self.cpt += 1
+                query_result.getNumItems.side_effect = lambda *a: 1
+                return query_result
+            if self.cpt == 1:
+                test = mock.Mock()
+                test.configure_mock()
+                ret = []
+                for v in ['test_(1)', 'test_(3)']:
+                    m = mock.Mock()
+                    m.configure_mock(name=v)
+                    ret.append(m)
+                query_result.__iter__.return_value = ret
+                return query_result
+        # if the same name is found and the folder_name_conflict_handler ==
+        # 'increment' the method must return a new name with a suffix _(X)
+        # where X is the value max found as X for the same name + 1
+        self.backend_instance.folder_name_conflict_handler = 'increment'
+        repository.query.side_effect = query
+        name = self.backend_instance.get_unique_folder_name(
+            'test', mocked_parent)
+        self.assertEqual('test_(4)', name)

--- a/cmis_field/tests/test_fields.py
+++ b/cmis_field/tests/test_fields.py
@@ -178,4 +178,4 @@ class TestCmisFields(common.BaseTestCmis):
         self.cmis_backend.unlink()
         descr = inst._fields['cmis_folder'].get_description(self.env)
         backend_description = descr.get('backend')
-        self.assertTrue('backend_error' in descr.get('backend'))
+        self.assertTrue('backend_error' in backend_description)

--- a/cmis_field/views/cmis_backend_view.xml
+++ b/cmis_field/views/cmis_backend_view.xml
@@ -9,6 +9,7 @@
           <field name="location" position="after">
               <field name="enable_sanitize_cmis_name" colspan="2"/>
               <field name="sanitize_replace_char" colspan="2" attrs="{'invisible': [('enable_sanitize_cmis_name', '=', False)]}"/>
+              <field name="folder_name_conflict_handler" colspan="4"/>
           </field>
       </field>
     </record>

--- a/cmis_web_alf/models/cmis_backend.py
+++ b/cmis_web_alf/models/cmis_backend.py
@@ -2,6 +2,7 @@
 # Copyright 2016 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+# pylint: disable=missing-import-error, missing-manifest-dependency
 from cmislib.browser.binding import safe_urlencode
 from openerp import api, models
 


### PR DESCRIPTION
A new parameter on the backend let's you choice between 2 strategies:
'error' or 'increment. If a folder already exists with the same name,
the system will raise an error if 'error' is specified as strategy
(default) otherwise a suffix is added to the name to make it unique.