### PR TITLE
[10.0] [FIX] cmis_web: Display only the buttons in the main toolbar for whic…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 10.?.?.?.? (?)
 ~~~~~~~~~~~~~~
 
+* Fix: Display only the buttons in the main toolbar for which the user has the
+  appropriate permissions.
 * Fix: JS error when multiple documents are uploaded at once.
 
 

--- a/cmis_web/static/src/xml/form_widgets.xml
+++ b/cmis_web/static/src/xml/form_widgets.xml
@@ -115,14 +115,16 @@
          <span class="btn-separator"></span>
        <div class="btn-group">
          <button type="button"
-                 t-attf-class="btn btn-default btn-sm root-content-action-new-folder {{ (canCreateFolder)?'': 'disabled' }}"
+                 t-if="canCreateFolder"
+                 t-attf-class="btn btn-default btn-sm root-content-action-new-folder"
                  data-toggle="tooltip"
                  title="Create folder"
                  aria-label="Create folder">
              <span class="glyphicon glyphicon-folder-close" aria-hidden="true"></span>
          </button>
          <button type="button"
-                 t-attf-class="btn btn-default btn-sm root-content-action-new-doc {{ (canCreateDocument)?'': 'disabled' }}"
+                 t-if="canCreateDocument"
+                 t-attf-class="btn btn-default btn-sm root-content-action-new-doc"
                  data-toggle="tooltip"
                  title="Add document"
                  aria-label="Add document">


### PR DESCRIPTION
…h the user has the  appropriate permissions.