### PR TITLE
[10.0][IMP] Handle name conflict on folder create.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 10.?.?.?.? (?)
 ~~~~~~~~~~~~~~
 
+* Improvement: Handle name conflict on folder create.
+  A new parameter on the backend let's you choice between 2 strategies:
+  'error' or 'increment. If a folder already exists with the same name, the
+  system will raise an error if 'error' is specified as strategy (default)
+  otherwise a suffix is added to the name to make it unique.
 * Fix: Refresh the document before downloading or opening it into alfresco
   to always get the latest version. (issue #83)
 * Fix: Display only the buttons in the main toolbar for which the user has the
@@ -11,7 +16,6 @@
 10.0.2.0.0 (Oct, 17, 2017)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Improvement: New document viewer.
 * Improvement: Allow the preview of image files.
 * Fix: Display the node title if set into the CMIS container.
 * Fix: On the import document dialog, rename 'Create' button into 'Add'

--- a/cmis_field/fields/cmis_folder.py
+++ b/cmis_field/fields/cmis_folder.py
@@ -121,6 +121,7 @@ class CmisFolder(fields.Field):
             else:
                 backend.is_valid_cmis_name(name, raise_if_invalid=True)
             parent = parents[record.id]
+            name = backend.get_unique_folder_name(name, parent)
             props = properties[record.id] or {}
             value = repo.createFolder(
                 parent, name, props)

--- a/cmis_field/models/cmis_backend.py
+++ b/cmis_field/models/cmis_backend.py
@@ -34,6 +34,15 @@ class CmisBackend(models.Model):
         help='Character used as replacement of invalid characters found in'
              'the value to use as cmis:name by the sanitize method',
         default='_')
+    folder_name_conflict_handler = fields.Selection(
+        selection=[
+            ('error', _('Raise exception')),
+            ('increment', _('Create as "name_(X)"'))
+        ],
+        string='Strategy in case of duplicate',
+        required=True,
+        default='error',
+    )
 
     @api.model
     def _get_web_description(self, record):
@@ -120,3 +129,41 @@ class CmisBackend(models.Model):
         path = "/".join(path_parts)
         return self.get_folder_by_path(
             path, create_if_not_found, cmis_parent_objectid)
+
+    @api.multi
+    def get_unique_folder_name(self, name, parent, conflict_handler=None):
+        """Return a unique name for a folder into its parent.
+
+        Check if the name already exists into the parent.
+        If the name already exists:
+         if bakend.folder_name_conflict_handler == 'error'
+            ValidationError is raised
+         if backend.folder_name_conflict_handler == 'increment'
+            return a new name with suffix '_X'
+        :return: a unique name
+        """
+        self.ensure_one()
+        conflict_handler = (conflict_handler or
+                            self.folder_name_conflict_handler)
+        cmis_qry = ("SELECT cmis:objectId FROM cmis:folder WHERE "
+                    "IN_FOLDER('%s') AND cmis:name='%s'" %
+                    (parent.getObjectId(), name))
+        rs = parent.repository.query(cmis_qry)
+        num_found_items = rs.getNumItems()
+        if num_found_items > 0:
+            if conflict_handler == 'error':
+                raise ValidationError(
+                    _('Folder "%s" already exists in CMIS') % (name))
+            if conflict_handler == 'increment':
+                testname = name + '_(%)'
+                cmis_qry = ("SELECT * FROM cmis:folder WHERE "
+                            "IN_FOLDER('%s') AND cmis:name like '%s'" %
+                            (parent.getObjectId(), testname))
+                rs = parent.repository.query(cmis_qry)
+                names = [r.name for r in rs]
+                max_num = 0
+                if names:
+                    max_num = max(
+                        [int(re.findall(r'_\((\d+)\)', n)[-1]) for n in names])
+                return name + '_(%d)' % (max_num + 1)
+        return name

--- a/cmis_field/tests/common.py
+++ b/cmis_field/tests/common.py
@@ -31,3 +31,20 @@ class BaseTestCmis(common.SavepointCase):
         cls.cmis_test_model = cls._init_test_model(models.CmisTestModel)
         cls.cmis_backend = cls.env.ref('cmis.cmis_backend_alfresco')
         cls.cmis_backend.initial_directory_write = '/odoo'
+
+    def setUp(self):
+        super(BaseTestCmis, self).setUp()
+
+        # global patch
+
+        def get_unique_folder_name(name, parent):
+            return name
+        self.patched_get_unique_folder_name = mock.patch.object(
+            self.cmis_backend.__class__, 'get_unique_folder_name',
+            side_effect=get_unique_folder_name
+        )
+        self.patched_get_unique_folder_name.start()
+
+    def tearDown(self):
+        super(BaseTestCmis, self).tearDown()
+        self.patched_get_unique_folder_name.stop()

--- a/cmis_field/tests/test_cmis_backend.py
+++ b/cmis_field/tests/test_cmis_backend.py
@@ -3,8 +3,9 @@
 # Copyright 2016 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo.tests import common
+import mock
 from odoo.exceptions import UserError, ValidationError
+from odoo.tests import common
 
 
 class TestCmisBackend(common.SavepointCase):
@@ -59,3 +60,46 @@ class TestCmisBackend(common.SavepointCase):
         sanitized = self.backend_instance.sanitize_cmis_names(
             ['/y dir*', 'sub/dir'], ' ')
         self.assertEqual(sanitized, ['y dir', 'sub dir'])
+
+    def test_get_unique_folder_name(self):
+        mocked_parent = mock.MagicMock()
+        # if no name found, the method return the same name
+        repository = mock.MagicMock()
+        mocked_parent.repository = repository
+        query_result = mock.MagicMock()
+        repository.query.side_effect = lambda *a: query_result
+        query_result.getNumItems.side_effect = lambda *a: 0
+        self.assertEqual('test', self.backend_instance.get_unique_folder_name(
+            'test', mocked_parent))
+        # if the same name is found and the folder_name_conflict_handler ==
+        # 'error' a ValidationError is raised
+        query_result.getNumItems.side_effect = lambda *a: 1
+        self.backend_instance.folder_name_conflict_handler = 'error'
+        with self.assertRaises(ValidationError):
+            self.backend_instance.get_unique_folder_name('test', mocked_parent)
+
+        self.cpt = 0
+
+        def query(q):
+            if self.cpt == 0:
+                self.cpt += 1
+                query_result.getNumItems.side_effect = lambda *a: 1
+                return query_result
+            if self.cpt == 1:
+                test = mock.Mock()
+                test.configure_mock()
+                ret = []
+                for v in ['test_(1)', 'test_(3)']:
+                    m = mock.Mock()
+                    m.configure_mock(name=v)
+                    ret.append(m)
+                query_result.__iter__.return_value = ret
+                return query_result
+        # if the same name is found and the folder_name_conflict_handler ==
+        # 'increment' the method must return a new name with a suffix _(X)
+        # where X is the value max found as X for the same name + 1
+        self.backend_instance.folder_name_conflict_handler = 'increment'
+        repository.query.side_effect = query
+        name = self.backend_instance.get_unique_folder_name(
+            'test', mocked_parent)
+        self.assertEqual('test_(4)', name)

--- a/cmis_field/tests/test_fields.py
+++ b/cmis_field/tests/test_fields.py
@@ -178,4 +178,4 @@ class TestCmisFields(common.BaseTestCmis):
         self.cmis_backend.unlink()
         descr = inst._fields['cmis_folder'].get_description(self.env)
         backend_description = descr.get('backend')
-        self.assertTrue('backend_error' in descr.get('backend'))
+        self.assertTrue('backend_error' in backend_description)

--- a/cmis_field/views/cmis_backend_view.xml
+++ b/cmis_field/views/cmis_backend_view.xml
@@ -9,6 +9,7 @@
           <field name="location" position="after">
               <field name="enable_sanitize_cmis_name" colspan="2"/>
               <field name="sanitize_replace_char" colspan="2" attrs="{'invisible': [('enable_sanitize_cmis_name', '=', False)]}"/>
+              <field name="folder_name_conflict_handler" colspan="4"/>
           </field>
       </field>
     </record>

--- a/cmis_web_alf/models/cmis_backend.py
+++ b/cmis_web_alf/models/cmis_backend.py
@@ -2,6 +2,7 @@
 # Copyright 2016 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+# pylint: disable=missing-import-error, missing-manifest-dependency
 from cmislib.browser.binding import safe_urlencode
 from odoo import api, models
 

--- a/cmis_web_alf/models/cmis_backend.py
+++ b/cmis_web_alf/models/cmis_backend.py
@@ -2,7 +2,7 @@
 # Copyright 2016 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-# pylint: disable=missing-import-error, missing-manifest-dependency
+
 from cmislib.browser.binding import safe_urlencode
 from odoo import api, models
 


### PR DESCRIPTION
A new parameter on the backend let's you choice between 2 strategies:
'error' or 'increment. If a folder already exists with the same name,
the system will raise an error if 'error' is specified as strategy
(default) otherwise a suffix is added to the name to make it unique.