### PR TITLE
[FIX] cmis_field: copy=False is now the default on CmisFolder fields.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+10.0.3.0.1 (Jan, 30, 2018)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Fix: copy=False is now the default on CmisFolder fields.
+
 10.0.3.0.0 (Dec, 21, 2017)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/cmis_field/__manifest__.py
+++ b/cmis_field/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Alfodoo CMIS Field',
-    'version': '10.0.3.0.0',
+    'version': '10.0.3.0.1',
     'summary': 'Specialized field to work with a CMIS server',
     'category': 'Document Management',
     'author': "ACSONE SA/NV ",

--- a/cmis_field/fields/cmis_folder.py
+++ b/cmis_field/fields/cmis_folder.py
@@ -68,7 +68,8 @@ class CmisFolder(fields.Field):
         'create_parent_get': None,
         'create_properties_get': None,
         'allow_create': True,
-        'allow_delete': False
+        'allow_delete': False,
+        'copy': False,  # noderef are not copied by default
     }
 
     def __init__(self, backend_name=None, string=None, **kwargs):

--- a/cmis_field/tests/test_fields.py
+++ b/cmis_field/tests/test_fields.py
@@ -179,3 +179,24 @@ class TestCmisFields(common.BaseTestCmis):
         descr = inst._fields['cmis_folder'].get_description(self.env)
         backend_description = descr.get('backend')
         self.assertTrue('backend_error' in backend_description)
+
+    def test_cmis_folder_copy_false(self):
+        # By default the cmis_folder value must not be copied.
+        inst1 = self.env['cmis.test.model'].create({'name': 'folder_name1'})
+        self.assertFalse(inst1._fields['cmis_folder'].copy)
+        with mock.patch("odoo.addons.cmis.models.cmis_backend."
+                        "CmisBackend.get_cmis_repository") as \
+                mocked_get_repository:
+            mocked_cmis_repository = mock.MagicMock()
+            mocked_get_repository.return_value = mocked_cmis_repository
+
+            def my_side_effect(parent, name, prop=None):
+                new_object_mock = mock.MagicMock()
+                new_object_mock.getObjectId.return_value = "id1"
+                return new_object_mock
+
+            mocked_cmis_repository.createFolder.side_effect = my_side_effect
+            inst1._fields['cmis_folder'].create_value(inst1)
+            self.assertEquals(inst1.cmis_folder, "id1")
+            copy_inst1 = inst1.copy()
+            self.assertFalse(copy_inst1.cmis_folder)


### PR DESCRIPTION
fixes #97