### PR TITLE
[IMP] cmis_proxy: Improve modularity of _check_access_operation

### DIFF
--- a/cmis_web_proxy/controllers/cmis.py
+++ b/cmis_web_proxy/controllers/cmis.py
@@ -135,7 +135,34 @@ class CmisProxy(http.Controller):
                 values[k] = v.replace(original, new)
 
     def _check_access_operation(self, model_inst, operation):
+        """
+        Check if the user has the appropriate rights to perform the operation.
+        The default is to check the access rights and access rules on the
+        model instance. This behaviour can be adapted by defining the method
+        ''_check_cmis_access_operation'' on the model.
+        ::
+            @api.multi
+            def _check_cmis_access_operation(self, operation, field_name=None):
+                if my_true_condition:
+                    return True
+                if my_false_condition:
+                     return False
+                return None
+
+        The expected result must be in ('allow', 'deny', 'default'.
+        * allow: Access granted
+        * deny: Access Denied
+        * default: The current method will check the access rights and access
+                rules
+        """
         try:
+            if hasattr(model_inst, '_check_cmis_access_operation'):
+                res = model_inst._check_cmis_access_operation(operation, None)
+                if res not in ('allow', 'deny', 'default'):
+                    raise ValueError("_check_cmis_access_operation result "
+                                     "must be in ('allow', 'deny', 'default')")
+                if res != 'default':
+                    return res == 'allow'
             model_inst.check_access_rights(operation)
             model_inst.check_access_rule(operation)
         except AccessError:

--- a/cmis_web_proxy/controllers/cmis.py
+++ b/cmis_web_proxy/controllers/cmis.py
@@ -144,16 +144,16 @@ class CmisProxy(http.Controller):
             @api.multi
             def _check_cmis_access_operation(self, operation, field_name=None):
                 if my_true_condition:
-                    return True
+                    return 'allow'
                 if my_false_condition:
-                     return False
-                return None
+                     return 'deny'
+                return 'default'
 
-        The expected result must be in ('allow', 'deny', 'default'.
+        The expected result must be in ('allow', 'deny', 'default').
         * allow: Access granted
         * deny: Access Denied
         * default: The current method will check the access rights and access
-                rules
+                   rules
         """
         try:
             if hasattr(model_inst, '_check_cmis_access_operation'):


### PR DESCRIPTION
It's now possible to define a method '_check_cmis_access_operation' on the model to adapt the _check_access_operation behaviour. If the method return True or False, the normal behaviour is skipped. If None, the check fallback on its normal impementation