### PR TITLE
10.0 dev

### DIFF
--- a/cmis_field/fields/cmis_folder.py
+++ b/cmis_field/fields/cmis_folder.py
@@ -101,6 +101,12 @@ class CmisFolder(fields.Field):
         """
         for record in records:
             self._check_null(record)
+        if self.related:
+            self._create_value_related(records)
+        else:
+            self._create_value(records)
+
+    def _create_value(self, records):
         backend = self.get_backend(records.env)
         if self.create_method:
             fct = self.create_method
@@ -109,6 +115,16 @@ class CmisFolder(fields.Field):
             fct(self, backend)
             return
         self._create_in_cmis(records, backend)
+
+    def _create_value_related(self, records):
+        others = records.sudo() if self.related_sudo else records
+        for record, other in zip(records, others):
+            if not record.id and record.env != other.env:
+                # draft records: copy record's cache to other's cache first
+                fields.copy_cache(record, other.env)
+            other, field = self.traverse_related(other)
+            field.create_value(other)
+            record[self.name] = other[field.name]
 
     def _create_in_cmis(self, records, backend):
         names = self.get_create_names(records, backend)

--- a/cmis_field/models/cmis_backend.py
+++ b/cmis_field/models/cmis_backend.py
@@ -75,8 +75,8 @@ class CmisBackend(models.Model):
         backend = self.search(domain)
         if len(backend) != 1 and raise_if_not_found:
             if name:
-                msg = _("Expected 1 backend named %s, %s found" %
-                        (name, len(backend)))
+                msg = _("Expected 1 backend named %s, %s found") % \
+                    (name, len(backend))
             else:
                 msg = _('No backend found')
             raise UserError(msg)

--- a/cmis_field/tests/common.py
+++ b/cmis_field/tests/common.py
@@ -28,7 +28,15 @@ class BaseTestCmis(common.SavepointCase):
         super(BaseTestCmis, cls).setUpClass()
         # mock commit since it"s called in the _auto_init method
         cls.cr.commit = mock.MagicMock()
-        cls.cmis_test_model = cls._init_test_model(models.CmisTestModel)
+        cls.cmis_test_model = cls._init_test_model(
+            models.CmisTestModel
+        )
+        cls.cmis_test_model_inherits = cls._init_test_model(
+            models.CmisTestModelInherits
+        )
+        cls.cmis_test_model_related = cls._init_test_model(
+            models.CmisTestModelRelated
+        )
         cls.cmis_backend = cls.env.ref('cmis.cmis_backend_alfresco')
         cls.cmis_backend.initial_directory_write = '/odoo'
 

--- a/cmis_field/tests/models.py
+++ b/cmis_field/tests/models.py
@@ -42,3 +42,37 @@ class CmisTestModel(models.Model):
     cmis_folder2 = CmisFolder(
         backend_name='alfresco',
         create_method='_cmis_create')
+
+
+class CmisTestModelInherits(models.Model):
+    _name = 'cmis.test.model.inherits'
+    _inherits = {'cmis.test.model': 'cmis_test_model_id'}
+    _abstract = True
+
+    cmis_test_model_id = fields.Many2one(
+        'cmis.test.model',
+        'Parent',
+        ondelete="cascade",
+        required=True
+    )
+
+
+class CmisTestModelRelated(models.Model):
+    _name = 'cmis.test.model.related'
+    _abstract = True
+
+    name = fields.Char(required=True)
+
+    cmis_test_model_id = fields.Many2one(
+        'cmis.test.model',
+        'Parent',
+        ondelete="cascade",
+        required=True
+    )
+    cmis_folder1 = CmisFolder(
+        related='cmis_test_model_id.cmis_folder1'
+    )
+
+    cmis_folder2 = CmisFolder(
+        related='cmis_test_model_id.cmis_folder2'
+    )

--- a/cmis_field/tests/test_cmis_backend.py
+++ b/cmis_field/tests/test_cmis_backend.py
@@ -95,6 +95,7 @@ class TestCmisBackend(common.SavepointCase):
                     ret.append(m)
                 query_result.__iter__.return_value = ret
                 return query_result
+            return None
         # if the same name is found and the folder_name_conflict_handler ==
         # 'increment' the method must return a new name with a suffix _(X)
         # where X is the value max found as X for the same name + 1

--- a/cmis_field/tests/test_fields.py
+++ b/cmis_field/tests/test_fields.py
@@ -144,9 +144,8 @@ class TestCmisFields(common.BaseTestCmis):
                 if name == "folder_name1":
                     new_object_mock.getObjectId.return_value = "id1"
                     return new_object_mock
-                else:
-                    new_object_mock.getObjectId.return_value = "id2"
-                    return new_object_mock
+                new_object_mock.getObjectId.return_value = "id2"
+                return new_object_mock
             mocked_cmis_repository.createFolder.side_effect = my_side_effect
             inst1._fields['cmis_folder'].create_value(inst1 + inst2)
             self.assertEquals(inst1.cmis_folder, "id1")

--- a/cmis_web/i18n/fr.po
+++ b/cmis_web/i18n/fr.po
@@ -376,6 +376,13 @@ msgstr "Nom"
 #. openerp-web
 #: code:addons/cmis_web/static/src/js/form_widgets.js:950
 #, python-format
+msgid "New name"
+msgstr "Nouveau nom"
+
+#. module: cmis_web
+#. openerp-web
+#: code:addons/cmis_web/static/src/js/form_widgets.js:950
+#, python-format
 msgid "Next"
 msgstr "Suivant"
 
@@ -462,6 +469,13 @@ msgstr "Rafraichir le contenu de la table"
 #, python-format
 msgid "Rename as"
 msgstr "Renommer en"
+
+#. module: cmis_web
+#. openerp-web
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:257
+#, python-format
+msgid "Rename"
+msgstr "Renommer"
 
 #. module: cmis_web
 #. openerp-web

--- a/cmis_web/i18n/fr.po
+++ b/cmis_web/i18n/fr.po
@@ -22,154 +22,177 @@ msgstr ""
 msgid " is editing this file. If it's not you any changes you make might be lost."
 msgstr " modifie ce fichier. Si ce  n'est pas vous, tous les changements que vous pourriez faire seront perdus."
 
+
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:828
+#: code:addons/cmis_web/static/src/js/form_widgets.js:68
+#, python-format
+msgid " already exists"
+msgstr " existe déjà"
+
+#. module: cmis_web
+#. openerp-web
+#: code:addons/cmis_web/static/src/js/form_widgets.js:939
 #, python-format
 msgid "(filtered from _MAX_ total entries)"
 msgstr "(filtré de _MAX_ éléments au total)"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:843
+#: code:addons/cmis_web/static/src/js/form_widgets.js:954
 #, python-format
 msgid ": activate to sort column ascending"
 msgstr ": activer pour trier la colonne par ordre croissant"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:844
+#: code:addons/cmis_web/static/src/js/form_widgets.js:955
 #, python-format
 msgid ": activate to sort column descending"
 msgstr ": activer pour trier la colonne par ordre décroissant"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:90
+#: code:addons/cmis_web/static/src/js/form_widgets.js:212
 #, python-format
 msgid "Add"
 msgstr "Ajouter"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:136
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:138
 #, python-format
 msgid "Add document"
 msgstr "Ajouter un document"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:197
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:214
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:253
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:199
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:216
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:299
 #, python-format
 msgid "Browse&hellip;"
 msgstr "Parcourir&hellip;"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:370
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:103
+#: code:addons/cmis_web/static/src/js/form_widgets.js:481
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:105
 #, python-format
 msgid "By:"
 msgstr "Par:"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:495
+#: code:addons/cmis_web/static/src/js/form_widgets.js:606
 #, python-format
 msgid "CMIS Backend Config Error"
 msgstr "CMIS Backend Config Error"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:568
+#: code:addons/cmis_web/static/src/js/form_widgets.js:679
 #, python-format
 msgid "CMIS Error"
 msgstr "Erreur CMIS"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:561
+#: code:addons/cmis_web/static/src/js/form_widgets.js:673
 #, python-format
 msgid "CMIS Error "
 msgstr "Erreur CMIS"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:233
+#: code:addons/cmis_web/static/src/js/form_widgets.js:52
 #, python-format
-msgid "Click here to see more technical info"
-msgstr "Cliquez ici pour voir les détails techniques"
+msgid "Cancel"
+msgstr "Annuler"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:179
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:181
 #, python-format
 msgid "Cancel Edit"
 msgstr "Annuler l'édition"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:51
-#: code:addons/cmis_web/static/src/js/form_widgets.js:99
-#: code:addons/cmis_web/static/src/js/form_widgets.js:180
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:326
+#, python-format
+msgid "Click here to see more technical info"
+msgstr "Cliquez ici pour voir les détails techniques"
+
+#. module: cmis_web
+#. openerp-web
+#: code:addons/cmis_web/static/src/js/form_widgets.js:173
+#: code:addons/cmis_web/static/src/js/form_widgets.js:221
+#: code:addons/cmis_web/static/src/js/form_widgets.js:295
 #, python-format
 msgid "Close"
 msgstr "Fermer"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:788
+#: code:addons/cmis_web/static/src/js/form_widgets.js:899
 #, python-format
 msgid "Columns"
 msgstr "Colonnes"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:240
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:242
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:283
 #, python-format
 msgid "Comment"
 msgstr "Commentaire"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:1186
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1309
 #, python-format
 msgid "Confirm deletion of "
 msgstr "Veuillez confirmer la suppression de "
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:43
+#: code:addons/cmis_web/static/src/js/form_widgets.js:165
 #, python-format
 msgid "Create"
 msgstr "Créer"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:111
+#: code:addons/cmis_web/static/src/js/form_widgets.js:233
 #, python-format
 msgid "Create Documents "
 msgstr "Ajouter un/des documents"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:58
+#: code:addons/cmis_web/static/src/js/form_widgets.js:180
 #, python-format
 msgid "Create Folder "
 msgstr "Ajouter un répertoire"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:233
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:235
 #, python-format
 msgid "Create a new major version"
 msgstr "Créer une nouvelle version majeure"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:128
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:269
+#, python-format
+msgid "Create a new version"
+msgstr "Créer une nouvelle version"
+
+#. module: cmis_web
+#. openerp-web
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:130
 #, python-format
 msgid "Create folder"
 msgstr "Ajouter un répertoire"
@@ -183,35 +206,35 @@ msgstr "Créer le répertoire dans la GED"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:227
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:229
 #, python-format
 msgid "Create new minor version"
 msgstr "Créer une nouvelle version mineure"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:736
+#: code:addons/cmis_web/static/src/js/form_widgets.js:847
 #, python-format
 msgid "Create your object first"
 msgstr "Veuillez d'abord enregistrer votre objet une première fois."
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:88
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:90
 #, python-format
 msgid "Created By"
 msgstr "Créé par"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:84
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:86
 #, python-format
 msgid "Creation Date"
 msgstr "Date de création"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:183
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:185
 #, python-format
 msgid "Delete"
 msgstr "Supprimer"
@@ -227,71 +250,71 @@ msgstr "Description"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:151
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:153
 #, python-format
 msgid "Download"
 msgstr "Télécharger"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:837
+#: code:addons/cmis_web/static/src/js/form_widgets.js:948
 #, python-format
 msgid "First"
 msgstr "Premier"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:267
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:313
 #, python-format
 msgid "Folder Name:"
 msgstr "Nom du répertoire:"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:262
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:178
+#: code:addons/cmis_web/static/src/js/form_widgets.js:376
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:180
 #, python-format
 msgid "Import new version"
 msgstr "Importer une nouvelle version"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:263
+#: code:addons/cmis_web/static/src/js/form_widgets.js:377
 #, python-format
 msgid "Import new version of "
 msgstr "Importer une nouvelle version de "
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:101
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:103
 #, python-format
 msgid "Is Checked Out"
 msgstr "Verrouillé"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:838
+#: code:addons/cmis_web/static/src/js/form_widgets.js:949
 #, python-format
 msgid "Last"
 msgstr "Dernier"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:96
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:98
 #, python-format
 msgid "Last Modified By"
 msgstr "Dernière modification par"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:92
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:94
 #, python-format
 msgid "Last Modified Date"
 msgstr "Date de dernière modification"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:832
+#: code:addons/cmis_web/static/src/js/form_widgets.js:943
 #, python-format
 msgid "Loading..."
 msgstr "Chargement en cours..."
@@ -302,6 +325,20 @@ msgstr "Chargement en cours..."
 #, python-format
 msgid "MIME Type"
 msgstr "MIME Type"
+
+#. module: cmis_web
+#. openerp-web
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:277
+#, python-format
+msgid "Major"
+msgstr "Majeure"
+
+#. module: cmis_web
+#. openerp-web
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:276
+#, python-format
+msgid "Minor"
+msgstr "Mineure"
 
 #. module: cmis_web
 #. openerp-web
@@ -321,7 +358,7 @@ msgstr "Modifié par"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:171
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:173
 #, python-format
 msgid "More actions"
 msgstr "Actions supplémentaires"
@@ -337,28 +374,28 @@ msgstr "Nom"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:839
+#: code:addons/cmis_web/static/src/js/form_widgets.js:950
 #, python-format
 msgid "Next"
 msgstr "Suivant"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:825
+#: code:addons/cmis_web/static/src/js/form_widgets.js:936
 #, python-format
 msgid "No data available in table"
 msgstr "Aucun élément à afficher"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:835
+#: code:addons/cmis_web/static/src/js/form_widgets.js:946
 #, python-format
 msgid "No matching records found"
 msgstr "Aucune donnée disponible"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:166
+#: code:addons/cmis_web/static/src/js/form_widgets.js:281
 #, python-format
 msgid "OK"
 msgstr "OK"
@@ -379,70 +416,84 @@ msgstr "Type de contenu"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:180
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:182
 #, python-format
 msgid "Offline Edit"
 msgstr "Editer hors ligne"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:160
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:162
 #, python-format
 msgid "Preview"
 msgstr "Prévisualiser"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:840
+#: code:addons/cmis_web/static/src/js/form_widgets.js:951
 #, python-format
 msgid "Previous"
 msgstr "Précédent"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:833
+#: code:addons/cmis_web/static/src/js/form_widgets.js:43
+#, python-format
+msgid "Process"
+msgstr "Exécuter"
+
+#. module: cmis_web
+#. openerp-web
+#: code:addons/cmis_web/static/src/js/form_widgets.js:944
 #, python-format
 msgid "Processing..."
 msgstr "Traitement en cours..."
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:118
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:120
 #, python-format
 msgid "Refresh content table"
 msgstr "Rafraichir le contenu de la table"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:1326
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:257
+#, python-format
+msgid "Rename as"
+msgstr "Renommer en"
+
+#. module: cmis_web
+#. openerp-web
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1459
 #, python-format
 msgid "Root"
 msgstr "Racine"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:834
+#: code:addons/cmis_web/static/src/js/form_widgets.js:945
 #, python-format
 msgid "Search:"
 msgstr "Recherche:"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:831
+#: code:addons/cmis_web/static/src/js/form_widgets.js:942
 #, python-format
 msgid "Show _MENU_ entries"
 msgstr "Afficher _MENU_ éléments"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:827
+#: code:addons/cmis_web/static/src/js/form_widgets.js:938
 #, python-format
 msgid "Showing 0 to 0 of 0 entries"
 msgstr "Affichage de l'élément 0 à 0 sur 0 élément"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:826
+#: code:addons/cmis_web/static/src/js/form_widgets.js:937
 #, python-format
 msgid "Showing _START_ to _END_ of _TOTAL_ entries"
 msgstr "Affichage de l'élément _START_ à _END_ sur _TOTAL_ éléments"
@@ -458,35 +509,35 @@ msgstr "Titre"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:175
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:177
 #, python-format
 msgid "Update"
 msgstr "Mettre à jour"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:238
+#: code:addons/cmis_web/static/src/js/form_widgets.js:352
 #, python-format
 msgid "Update content"
 msgstr "Mettre à jour le contenu"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:239
+#: code:addons/cmis_web/static/src/js/form_widgets.js:353
 #, python-format
 msgid "Update content of "
 msgstr "Mise à jour du contenu de "
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:80
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:81
 #, python-format
 msgid "Version"
 msgstr "Version"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:174
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:176
 #, python-format
 msgid "View Details"
 msgstr "Afficher les détails"

--- a/cmis_web/static/src/js/form_widgets.js
+++ b/cmis_web/static/src/js/form_widgets.js
@@ -34,6 +34,128 @@
      },
  });
 
+ var CmisDuplicateDocumentResolver = Dialog.extend({
+     template: 'CmisDuplicateDocumentResolver',
+     init: function(parent, parent_cmisobject, file) {
+         var self = this;
+         var options = {
+             buttons: [
+                 {text: _t("Process"),
+                  classes: "btn-primary",
+                  click: function (e) {
+                      e.stopPropagation();
+                      if(self.check_validity()){
+                          self.on_click_process();
+                      }
+                  }
+                 },
+                 {text: _t("Cancel"),
+                  click: function (e) {
+                     e.stopPropagation();
+                     self.$el.parents('.modal').modal('hide');
+                   }
+                 },
+
+             ],
+             close: function () { self.close();}
+         };
+         this._super(parent, options);
+         this.parent_cmisobject = parent_cmisobject;
+         this.cmis_session = parent.cmis_session;
+         this.file = file;
+         this.new_filename = '';
+         this.original_objectId = '';
+         this.set_title(file.name + _t(" already exists"));
+     },
+
+     renderElement: function() {
+         this._super();
+         this.$new_filename = this.$el.find('#new-filename');
+         this.$new_filename.val(this.new_filename);
+     },
+
+     /**
+        * Method called between @see init and @see start. Performs asynchronous
+        * calls required by the rendering and the start method.
+      */
+     willStart: function () {
+         var self = this;
+         var re = /(?:\.([^.]+))?$/;
+         var parts = re.exec(this.file.name);
+         var name_without_ext = this.file.name.slice(0, -parts[1].length - 1);
+         var ext = parts[1];
+         // looks for an alternate filename
+         var dfd1 = $.Deferred();
+         this.cmis_session.query('' +
+             "SELECT cmis:name FROM cmis:document WHERE " +
+             "IN_FOLDER('" +  this.parent_cmisobject.objectId +
+             "') AND cmis:name like '" + name_without_ext + "-%." + ext + "'")
+             .ok(function(data){
+                 var cpt = data.results.length;
+                 var filenames = _.map(
+                     data.results,
+                     function(item){return item.succinctProperties['cmis:name'][0];});
+                 while (true) {
+                     self.new_filename = name_without_ext +'-' +
+                        cpt + '.' + ext;
+                     if (_.contains(filenames, self.new_filename)) {
+                         cpt+=1;
+                     } else {
+                         break;
+                     }
+                 }
+                 dfd1.resolve();
+             })
+            .notOk(function(error){
+                     self.getParent().on_cmis_error(error);
+                     dfd1.reject(error);
+            });
+         // get original document
+         var dfd2 = $.Deferred();
+         this.cmis_session.query('' +
+             "SELECT cmis:objectId FROM cmis:document WHERE " +
+             "IN_FOLDER('" +  this.parent_cmisobject.objectId +
+             "') AND cmis:name = '" + this.file.name + "'")
+             .ok(function(data){
+                 self.original_objectId = data.results[0].succinctProperties['cmis:objectId'];
+                 dfd2.resolve();
+             })
+            .notOk(function(error){
+                 self.getParent().on_cmis_error(error);
+                 dfd2.reject(error);
+            });
+         return $.when(this._super.apply(this, arguments),  dfd1.promise(), dfd2.promise());
+     },
+
+     on_click_process: function() {
+         var self = this;
+         var rename = this.$el.find("input:radio[name='duplicate-radios']:checked").val() === "rename";
+         if (rename){
+             this.cmis_session
+                 .createDocument(this.parent_cmisobject.objectId, this.file, {'cmis:name': this.$new_filename.val()}, this.file.mimeType)
+                 .ok(function(new_cmisobject) {
+                     self.getParent().trigger('cmis_node_created', [new_cmisobject]);
+                     self.$el.parents('.modal').modal('hide');
+                 });
+         } else {
+             var major = this.$el.find("#new-version-type").val() === "major";
+             var comment = this.$el.find('#comment').val();
+             self.cmis_session.checkOut(self.original_objectId)
+                 .ok(function(checkedOutNode) {
+                     self.cmis_session
+                         .checkIn(checkedOutNode.succinctProperties['cmis:objectId'], major, self.file.name, self.file, comment)
+                         .ok(function (data) {
+                             // after checkin the working copy must be deleted (self.data)
+                             // the date received into the response is the new version
+                             // created
+                             self.getParent().trigger('cmis_node_deleted', [self.original_objectId]);
+                             self.$el.parents('.modal').modal('hide');
+                         });
+                 });
+         }
+     }
+ });
+
  var CmisCreateFolderDialog = Dialog.extend({
      template: 'CmisCreateFolderDialog',
      init: function(parent, parent_cmisobject) {
@@ -1074,6 +1196,21 @@ var CmisMixin = {
                     framework.unblockUI();
                     self.trigger('cmis_node_created', [processedFiles]);
                 }
+            })
+            .notOk(function(error){
+                if (error){
+                    console.error(error.text);
+                    if (error.type == 'application/json') {
+                        var jerror = JSON.parse(error.text);
+                        if (jerror.exception === 'contentAlreadyExists'){
+                            var dialog = new CmisDuplicateDocumentResolver(self, self.dislayed_folder_cmisobject, file);
+                            dialog.open();
+                            framework.unblockUI();
+                            return;
+                        }
+                    }
+                 }
+                 self.on_cmis_error(error);
              });
         }, this);
     },
@@ -1373,6 +1510,7 @@ return {
     FieldCmisFolder: FieldCmisFolder,
     CmisCreateFolderDialog: CmisCreateFolderDialog,
     CmisCreateDocumentDialog: CmisCreateDocumentDialog,
+    CmisDuplicateDocumentResolver: CmisDuplicateDocumentResolver,
     DEFAULT_CMIS_OPTIONS: DEFAULT_CMIS_OPTIONS,
 };
 

--- a/cmis_web/static/src/js/form_widgets.js
+++ b/cmis_web/static/src/js/form_widgets.js
@@ -143,7 +143,7 @@
              self.cmis_session.checkOut(self.original_objectId)
                  .ok(function(checkedOutNode) {
                      self.cmis_session
-                         .checkIn(checkedOutNode.succinctProperties['cmis:objectId'], major, self.file.name, self.file, comment)
+                         .checkIn(checkedOutNode.succinctProperties['cmis:objectId'], major, {}, self.file, comment)
                          .ok(function (data) {
                              // after checkin the working copy must be deleted (self.data)
                              // the date received into the response is the new version
@@ -386,7 +386,7 @@
         var major = this.$el.find("input:radio[name='version-radios']:checked").val() === "major";
         var comment = this.$el.find('#comment').val();
         this.data.cmis_session
-            .checkIn(this.data.objectId, major, fileName, file, comment)
+            .checkIn(this.data.objectId, major, {}, file, comment)
             .ok(function(data) {
                 // after checkin the working copy must be deleted (self.data)
                 // the date received into the response is the new version

--- a/cmis_web/static/src/js/form_widgets.js
+++ b/cmis_web/static/src/js/form_widgets.js
@@ -1301,6 +1301,7 @@ var CmisMixin = {
                     self.render_folder_actions();
                 });
             this.display_folder_in_breadcrumb(folderId);
+            this.datatable.rows().clear();
             this.datatable.ajax.reload(null, true);
         } else {
             self.datatable.clear().draw();

--- a/cmis_web/static/src/js/form_widgets.js
+++ b/cmis_web/static/src/js/form_widgets.js
@@ -619,10 +619,10 @@ var CmisMixin = {
             return;
         }
         this.view.on("change:actual_mode", this, this.on_mode_change);
-        // hook on form view content changed:
-        this.getParent().on('view_content_has_changed', self, function () {
-            self.render_value();
-        });
+
+        // refresh the displayed forlder on reload.
+        this.getParent().on('load_record', this, this.reload_displayed_folder);
+
         // add a listener on parent tab if it exists in order to display the dataTable
         core.bus.on('DOM_updated', self.view.ViewManager.is_in_DOM, function () {
             self.add_tab_listener();
@@ -1269,6 +1269,15 @@ var CmisMixin = {
      */
     reset_breadcrumb: function(){
         this.$breadcrumb.empty();
+    },
+
+    reload_displayed_folder: function(){
+      if(! this.displayed_folder_id){
+          return;
+      }
+      var page_index = this.page_index;
+      this.page_index = -1; // force reload
+      this.display_folder(page_index, this.displayed_folder_id);
     },
 
     /**

--- a/cmis_web/static/src/less/form_widgets.less
+++ b/cmis_web/static/src/less/form_widgets.less
@@ -121,7 +121,8 @@ div.field_cmis_folder_content_actions {
 }
 
 form.cmis_update_content_stream,
-form.cmis_create_document {
+form.cmis_create_document,
+form.cmis_duplicate_document_resolver{
     .btn-file {
         overflow: hidden;
         position: relative;

--- a/cmis_web/static/src/xml/form_widgets.xml
+++ b/cmis_web/static/src/xml/form_widgets.xml
@@ -246,6 +246,50 @@
     </form>
 </t>
 
+<t t-name='CmisDuplicateDocumentResolver'>
+    <form class="form-horizontal cmis_duplicate_document_resolver" role="form" t-att-id="id">
+        <div class="form-group mb0">
+            <div class="col-sm-12">
+                <div class="form-group row mb0">
+                    <div class="form-check col-sm-3">
+                        <input checked="1"  class="form-check-input" id="rename-radios" name="duplicate-radios" value="rename" type="radio"
+                            data-toggle="collapse" data-target=".collaps_comment.in"/>
+                        <label class="form-check-label" for="rename-radio">
+                           Rename as
+                        </label>
+                    </div>
+                    <div class="col-sm-6">
+                        <input class="o_form_input" type="text" id="new-filename"/>
+                    </div>
+                </div>
+                <div class="form-group row mb0">
+                    <div class="form-check col-sm-3">
+                        <input class="form-check-input" id="new-version-radio" name="duplicate-radios" value="new-version" type="radio"
+                               data-toggle="collapse" data-target=".collaps_comment:not(.in)"/>
+                        <label class="form-check-label" for="new-version-radios">
+                           Create a new version
+                        </label>
+
+                    </div>
+                    <div class="col-sm-3">
+                        <select class="o_form_input" id="new-version-type">
+                            <option value="minor">Minor</option>
+                            <option value="major">Major</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="form-group row mb0 collaps_comment collapse">
+                    <div class="col-sm-12">
+                        <label for="comment">Comment</label>
+                        <textarea class="form-control" id="comment" rows="3"/>
+                    </div>
+                </div>
+
+            </div>
+        </div>
+    </form>
+</t>
+
 <t t-name='CmisCreateDocumentDialog'>
     <form class="form-horizontal cmis_create_document" role="form" t-att-id="id">
         <div class="form-group mb0">

--- a/cmis_web/static/src/xml/form_widgets.xml
+++ b/cmis_web/static/src/xml/form_widgets.xml
@@ -174,6 +174,7 @@
             </a>
             <ul class="dropdown-menu btn-block" t-att-aria-labelledby="object.getSuccinctProperty('cmis:objectId')">
                 <li t-if='canGetProperties'><a class='content-action-get-properties' href="#">View Details</a></li>
+                <li t-if='canUpdateProperties'><a class='content-action-rename' href="#">Rename</a></li>
                 <li t-if='canSetContentStream and !canCheckIn'><a class='content-action-set-content-stream' href="#">Update</a></li>
                 <!-- li t-if='canGetAllVersions'><a class='content-action-get-all-versions' href="#">Check Versions</a></li -->
                 <li t-if='canCheckIn or canCancelCheckOut or canCheckOut' role="separator" class="divider"></li>
@@ -285,6 +286,19 @@
                     </div>
                 </div>
 
+            </div>
+        </div>
+    </form>
+</t>
+
+<t t-name='CmisRenameContentDialog'>
+    <form class="form-horizontal cmis_rename_context" role="form" t-att-id="id">
+        <div class="form-group mb0">
+            <label for="page-name" class="col-sm-3 control-label">
+                New name:
+            </label>
+            <div class="col-sm-9">
+                <input type="text" id="new-name" class="form-control" autofocus="autofocus" required="required"/>
             </div>
         </div>
     </form>

--- a/cmis_web_alf/models/cmis_backend.py
+++ b/cmis_web_alf/models/cmis_backend.py
@@ -2,9 +2,34 @@
 # Copyright 2016 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from urllib import urlencode
 
-from cmislib.browser.binding import safe_urlencode
 from odoo import api, models
+
+
+def to_utf8(value):
+
+    """ Safe encodng of value to utf-8 taking care of unicode values
+    """
+    if isinstance(value, unicode):
+        value = value.encode('utf8')
+    return value
+
+
+def safe_urlencode(in_dict):
+
+    """
+    Safe encoding of values taking care of unicode values
+    urllib.urlencode doesn't like unicode values
+    """
+
+    def encoded_dict(in_dict):
+        out_dict = {}
+        for k, v in in_dict.iteritems():
+            out_dict[k] = to_utf8(v)
+        return out_dict
+
+    return urlencode(encoded_dict(in_dict))
 
 
 class CmisBackend(models.Model):

--- a/cmis_web_alf/static/src/js/form_widgets.js
+++ b/cmis_web_alf/static/src/js/form_widgets.js
@@ -30,7 +30,7 @@ form_widgets.CmisObjectWrapper.include({
       // By default, review are generated in alfresco the first time it's requested by share
       // Before this first access, the renditions on the cmis object is empty.
       // Use the alfresco API to trigger a first rendition of the document.
-      return this.alfresco_api_location + '/node/workspace/SpacesStore/' + this.versionSeriesId + '/content/thumbnails/pdf/' + this.name + '?c=force&lastModified=pdf%' + new Date().getUTCMilliseconds();
+      return this.alfresco_api_location + '/node/workspace/SpacesStore/' + this.versionSeriesId + '/content/thumbnails/pdf/' + encodeURI(this.name) + '?c=force&lastModified=pdf%' + new Date().getUTCMilliseconds();
     },
 
 });

--- a/cmis_web_proxy/controllers/cmis.py
+++ b/cmis_web_proxy/controllers/cmis.py
@@ -135,7 +135,34 @@ class CmisProxy(http.Controller):
                 values[k] = v.replace(original, new)
 
     def _check_access_operation(self, model_inst, operation):
+        """
+        Check if the user has the appropriate rights to perform the operation.
+        The default is to check the access rights and access rules on the
+        model instance. This behaviour can be adapted by defining the method
+        ''_check_cmis_access_operation'' on the model.
+        ::
+            @api.multi
+            def _check_cmis_access_operation(self, operation, field_name=None):
+                if my_true_condition:
+                    return True
+                if my_false_condition:
+                     return False
+                return None
+
+        The expected result must be in ('allow', 'deny', 'default'.
+        * allow: Access granted
+        * deny: Access Denied
+        * default: The current method will check the access rights and access
+                rules
+        """
         try:
+            if hasattr(model_inst, '_check_cmis_access_operation'):
+                res = model_inst._check_cmis_access_operation(operation, None)
+                if res not in ('allow', 'deny', 'default'):
+                    raise ValueError("_check_cmis_access_operation result "
+                                     "must be in ('allow', 'deny', 'default')")
+                if res != 'default':
+                    return res == 'allow'
             model_inst.check_access_rights(operation)
             model_inst.check_access_rule(operation)
         except AccessError:

--- a/cmis_web_proxy/controllers/cmis.py
+++ b/cmis_web_proxy/controllers/cmis.py
@@ -185,14 +185,14 @@ class CmisProxy(http.Controller):
         can_write = self._check_access_operation(model_inst, 'write')
         can_unlink = self._check_access_operation(model_inst, 'unlink')
         for allowable_actions in all_allowable_actions:
-            for action, value in allowable_actions.items():
+            for action, val in allowable_actions.items():
                 allowed = False
                 if action in READ_ACCESS_ALLOWABLE_ACTIONS:
-                    allowed = can_read and value
+                    allowed = can_read and val
                 elif action in WRITE_ACCESS_ALLOWABLE_ACTIONS:
-                    allowed = can_write and value
+                    allowed = can_write and val
                 elif action in UNLINK_ACCESS_ALLOWABLE_ACTIONS:
-                    allowed = can_unlink and value
+                    allowed = can_unlink and val
                 allowable_actions[action] = allowed
 
     def _sanitize_headers(self, headers):

--- a/cmis_web_proxy/controllers/cmis.py
+++ b/cmis_web_proxy/controllers/cmis.py
@@ -144,16 +144,16 @@ class CmisProxy(http.Controller):
             @api.multi
             def _check_cmis_access_operation(self, operation, field_name=None):
                 if my_true_condition:
-                    return True
+                    return 'allow'
                 if my_false_condition:
-                     return False
-                return None
+                     return 'deny'
+                return 'default'
 
-        The expected result must be in ('allow', 'deny', 'default'.
+        The expected result must be in ('allow', 'deny', 'default').
         * allow: Access granted
         * deny: Access Denied
         * default: The current method will check the access rights and access
-                rules
+                   rules
         """
         try:
             if hasattr(model_inst, '_check_cmis_access_operation'):


### PR DESCRIPTION
- [X] fix: cmis_web: clear rows before reloading the table to avoid error if an expanded row is no more into the reloaded info.
- [X] fix: prevent error on first preview if the document name contains invalid characters.
- [X] fix: refresh the table when the data on the current view are refreshed.
- [X] Improvement: cmis_proxy : Improve modularity of _check_access_operation. It's now possible to define a method '_check_cmis_access_operation' on the model to adapt the _check_access_operation behaviour.
- [X] Improvement: New dialog to resolve conflict when we try to create a new document with the same name as an existing one.
- [X] Improvement: New dialog to rename cmis content.
- [X] Ensure compatibility with the next version of cmislib (py3 compat) https://github.com/apache/chemistry-cmislib/pull/12
- [x] fix: cmis_field: Add support for cmis_folder defined as related