### PR TITLE
[9.0] [FIX] CMIS Web Proxy: default get value in _check_provided_token

### DIFF
--- a/cmis_web_proxy/controllers/cmis.py
+++ b/cmis_web_proxy/controllers/cmis.py
@@ -267,7 +267,7 @@ class CmisProxy(http.Controller):
         if token:
             token = token.replace('Bearer', '').strip()
         else:
-            token = params.get('token').strip()
+            token = (params.get('token') or '').strip()
         if 'token' in params:
             params.pop('token')
         if not token:


### PR DESCRIPTION
In order to avoid `AttributeError: 'NoneType' object has no attribute 'strip'` in logs.
It is a back port the 10.0 implementation https://github.com/acsone/alfodoo/blob/10.0/cmis_web_proxy/controllers/cmis.py#L274