### PR TITLE
[FIX] cmislib py3compat support

### DIFF
--- a/cmis_web_alf/models/cmis_backend.py
+++ b/cmis_web_alf/models/cmis_backend.py
@@ -2,9 +2,34 @@
 # Copyright 2016 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from urllib import urlencode
 
-from cmislib.browser.binding import safe_urlencode
 from odoo import api, models
+
+
+def to_utf8(value):
+
+    """ Safe encodng of value to utf-8 taking care of unicode values
+    """
+    if isinstance(value, unicode):
+        value = value.encode('utf8')
+    return value
+
+
+def safe_urlencode(in_dict):
+
+    """
+    Safe encoding of values taking care of unicode values
+    urllib.urlencode doesn't like unicode values
+    """
+
+    def encoded_dict(in_dict):
+        out_dict = {}
+        for k, v in in_dict.iteritems():
+            out_dict[k] = to_utf8(v)
+        return out_dict
+
+    return urlencode(encoded_dict(in_dict))
 
 
 class CmisBackend(models.Model):


### PR DESCRIPTION
Declare function removed from the next version of the cmislib library into the cmis_backend to make the addons compatible with this new version supporting Py3 and based on requests in place of httplib2