### PR TITLE
[10.0] next release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,18 @@
+10.0.5.0.0 (Oct, 10, 2019)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* cmis_field: Prevent error in unique name computation
+* cmis_field: Escape quote char "'" into query
+  This change fixes an error in the case when a folder with a single quote
+  into the name was creaed by the backend.
+* cmis_web: Fixes an error in the case when a file with a single quote
+  into the name was dropped two times in the same folder. Into the second
+  drop, the logic in charge of processing duplication of content do a cmis
+  query to check if a document with the same name already exists. The
+  error occured into this query since the single quote was not escaped.
+* cmis_web: cut / copy / paste feature
+* cmis_alf: Add method to support folder creation from space-template
+
 10.0.4.0.0 (Sep, 11, 2018)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/acsoo.cfg
+++ b/acsoo.cfg
@@ -1,3 +1,7 @@
+[flake8]
+flake8-options=
+  --ignore=W503,W504
+
 [pylint]
 pylint-options=
   --disable=locally-disabled

--- a/cmis_alf/__manifest__.py
+++ b/cmis_alf/__manifest__.py
@@ -19,6 +19,9 @@
     'images': [
         'static/description/main_icon.png',
     ],
+    'external_dependencies': {
+        'python': ['requests'],
+    },
     'installable': True,
     'auto_install': False,
 }

--- a/cmis_alf/models/cmis_backend.py
+++ b/cmis_alf/models/cmis_backend.py
@@ -2,12 +2,26 @@
 # © 2016 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import fields, models
+import requests
+from odoo import api, fields, models
 
 
 class CmisBackend(models.Model):
     _inherit = 'cmis.backend'
     _backend_type = 'cmis'
+
+    @api.multi
+    @api.depends('alfresco_api_location')
+    def _compute_alf_folder_template_url(self):
+        for record in self:
+            to_replace = "api"
+            if record.alfresco_api_location.endswith('/'):
+                to_replace = "api/"
+            location = record.alfresco_api_location.replace(
+                to_replace,
+                "slingshot/doclib/folder-templates"
+            )
+            record.alf_folder_template_url = location
 
     share_location = fields.Char(
         string='Alfresco Share Url',
@@ -20,3 +34,62 @@ class CmisBackend(models.Model):
         required=True,
         default='http://localhost:8080/alfresco/s/api'
     )
+
+    alf_folder_template_url = fields.Char(
+        compute='_compute_alf_folder_template_url'
+    )
+
+    @api.multi
+    def _get_alf_api_auth_params(self):
+        """
+        Return the parameters to use to make JSON requests to the alfresco api
+        :return:
+        """
+        self.ensure_one()
+        return(self.username, self.password)
+
+    @api.multi
+    def _get_alf_noderef_from_objectid(self, cmis_objectid):
+        """
+        Return the nodref from the cmis_objectid
+        :param cmis_objectid:
+        :return:
+        """
+        self.ensure_one()
+        repo = self.get_cmis_repository()
+        cmis_object = repo.getObject(cmis_objectid)
+        return cmis_object.properties['alfcmis:nodeRef']
+
+    @api.model
+    def _get_cmis_objectid_from_noderef(self, alf_noderef):
+        """
+        Return the cmis objectid from an alfresco  noderef
+        The alfresco noderef looks like
+        u'workspace://SpacesStore/1c8007c5-da05-4889-83e1-c8c43dbf4683' The
+        last part seems to always be the cmis_objectid
+        :param alf_noderef:
+        :return:
+        """
+        return alf_noderef.split('/')[-1]
+
+    @api.multi
+    def create_cmis_folder_from_template(self, source_objectid,
+                                         parent_objectid, name, title=None,
+                                         description=None):
+        """Create a new cmis folder from an alfresco space template.
+        """
+        self.ensure_one()
+        payload = {
+            "prop_cm_name": name,
+            "prop_cm_title": title or "",
+            "prop_cm_description": description or "",
+            "sourceNodeRef": self._get_alf_noderef_from_objectid(
+                source_objectid),
+            "parentNodeRef": self._get_alf_noderef_from_objectid(
+                parent_objectid)
+        }
+        r = requests.post(self.alf_folder_template_url, json=payload,
+                          auth=self._get_alf_api_auth_params())
+        r.raise_for_status()
+        new_noderef = r.json()['persistedObject']
+        return self._get_cmis_objectid_from_noderef(new_noderef)

--- a/cmis_alf/models/cmis_backend.py
+++ b/cmis_alf/models/cmis_backend.py
@@ -91,5 +91,15 @@ class CmisBackend(models.Model):
         r = requests.post(self.alf_folder_template_url, json=payload,
                           auth=self._get_alf_api_auth_params())
         r.raise_for_status()
-        new_noderef = r.json()['persistedObject']
-        return self._get_cmis_objectid_from_noderef(new_noderef)
+        resp = r.json()
+        if 'persistedObject' in resp:
+            # alfresco >= 5.1
+            new_noderef = resp['persistedObject']
+            return self._get_cmis_objectid_from_noderef(new_noderef)
+        # alfresco < 5.1
+        # reload new object from path
+        cmis_object = self.get_folder_by_path(
+            name,
+            create_if_not_found=False,
+            cmis_parent_objectid=parent_objectid)
+        return cmis_object.getObjectId()

--- a/cmis_field/models/cmis_backend.py
+++ b/cmis_field/models/cmis_backend.py
@@ -168,6 +168,7 @@ class CmisBackend(models.Model):
                         num = re.findall(r'_\((\d+)\)', n)
                         if num:
                             nums.append(int(num[0]))
-                    max_num = max(nums)
+                    if nums:
+                        max_num = max(nums)
                 return name + '_(%d)' % (max_num + 1)
         return name

--- a/cmis_field/models/cmis_backend.py
+++ b/cmis_field/models/cmis_backend.py
@@ -158,7 +158,8 @@ class CmisBackend(models.Model):
                 testname = name + '_(%)'
                 cmis_qry = ("SELECT * FROM cmis:folder WHERE "
                             "IN_FOLDER('%s') AND cmis:name like '%s'" %
-                            (parent.getObjectId(), testname))
+                            (parent.getObjectId(),
+                             testname.replace("'", "\\'")))
                 rs = parent.repository.query(cmis_qry)
                 names = [r.name for r in rs]
                 max_num = 0

--- a/cmis_field/models/cmis_backend.py
+++ b/cmis_field/models/cmis_backend.py
@@ -147,7 +147,7 @@ class CmisBackend(models.Model):
                             self.folder_name_conflict_handler)
         cmis_qry = ("SELECT cmis:objectId FROM cmis:folder WHERE "
                     "IN_FOLDER('%s') AND cmis:name='%s'" %
-                    (parent.getObjectId(), name))
+                    (parent.getObjectId(), name.replace("'", "\\'")))
         rs = parent.repository.query(cmis_qry)
         num_found_items = rs.getNumItems()
         if num_found_items > 0:

--- a/cmis_field/models/cmis_backend.py
+++ b/cmis_field/models/cmis_backend.py
@@ -21,7 +21,7 @@ class CmisBackend(models.Model):
                 raise ValidationError(
                     _("The character to use as replacement can not be one of"
                       "'%s'") % CMIS_NAME_INVALID_CHARS
-                    )
+                )
 
     enable_sanitize_cmis_name = fields.Boolean(
         'Sanitize name on content creation?',

--- a/cmis_field/models/cmis_backend.py
+++ b/cmis_field/models/cmis_backend.py
@@ -163,7 +163,11 @@ class CmisBackend(models.Model):
                 names = [r.name for r in rs]
                 max_num = 0
                 if names:
-                    max_num = max(
-                        [int(re.findall(r'_\((\d+)\)', n)[-1]) for n in names])
+                    nums = []
+                    for n in names:
+                        num = re.findall(r'_\((\d+)\)', n)
+                        if num:
+                            nums.append(int(num[0]))
+                    max_num = max(nums)
                 return name + '_(%d)' % (max_num + 1)
         return name

--- a/cmis_field/tests/test_cmis_backend.py
+++ b/cmis_field/tests/test_cmis_backend.py
@@ -89,7 +89,7 @@ class TestCmisBackend(common.SavepointCase):
                 test = mock.Mock()
                 test.configure_mock()
                 ret = []
-                for v in ['test_(1)', 'test_(3)']:
+                for v in ['test_(backup)', 'test_(1)', 'test_(3)']:
                     m = mock.Mock()
                     m.configure_mock(name=v)
                     ret.append(m)

--- a/cmis_field/tests/test_cmis_backend.py
+++ b/cmis_field/tests/test_cmis_backend.py
@@ -95,7 +95,7 @@ class TestCmisBackend(common.SavepointCase):
                     ret.append(m)
                 query_result.__iter__.return_value = ret
                 return query_result
-            return None
+            return None  # pragma: no cover
         # if the same name is found and the folder_name_conflict_handler ==
         # 'increment' the method must return a new name with a suffix _(X)
         # where X is the value max found as X for the same name + 1
@@ -104,3 +104,48 @@ class TestCmisBackend(common.SavepointCase):
         name = self.backend_instance.get_unique_folder_name(
             'test', mocked_parent)
         self.assertEqual('test_(4)', name)
+
+    def test_get_unique_folder_name_2(self):
+        mocked_parent = mock.MagicMock()
+        # if no name found, the method return the same name
+        repository = mock.MagicMock()
+        mocked_parent.repository = repository
+        query_result = mock.MagicMock()
+        repository.query.side_effect = lambda *a: query_result
+        query_result.getNumItems.side_effect = lambda *a: 0
+        self.assertEqual('test', self.backend_instance.get_unique_folder_name(
+            'test', mocked_parent))
+        # if the same name is found and the folder_name_conflict_handler ==
+        # 'error' a ValidationError is raised
+        query_result.getNumItems.side_effect = lambda *a: 1
+        self.backend_instance.folder_name_conflict_handler = 'error'
+        with self.assertRaises(ValidationError):
+            self.backend_instance.get_unique_folder_name('test', mocked_parent)
+
+        self.cpt = 0
+
+        # in this case a name is found put without increment
+        def query(q):
+            if self.cpt == 0:
+                self.cpt += 1
+                query_result.getNumItems.side_effect = lambda *a: 1
+                return query_result
+            if self.cpt == 1:
+                test = mock.Mock()
+                test.configure_mock()
+                ret = []
+                for v in ['test_(backup)']:
+                    m = mock.Mock()
+                    m.configure_mock(name=v)
+                    ret.append(m)
+                query_result.__iter__.return_value = ret
+                return query_result
+            return None  # pragma: no cover
+        # if no name is found and the folder_name_conflict_handler ==
+        # 'increment' the method must return a new name with a suffix _(X)
+        # where X is the value max found as X for the same name + 1
+        self.backend_instance.folder_name_conflict_handler = 'increment'
+        repository.query.side_effect = query
+        name = self.backend_instance.get_unique_folder_name(
+            'test', mocked_parent)
+        self.assertEqual('test_(1)', name)

--- a/cmis_field/tests/test_ir_model_fields.py
+++ b/cmis_field/tests/test_ir_model_fields.py
@@ -23,7 +23,7 @@ class TestIrModelFields(BaseTestCmis):
             'name': x_field,
             'model': 'res.company',
             'model_id': model_id,
-            })
+        })
         ir_model_fields = self.env['ir.model.fields']
         self.assertTrue(x_field in res_company._fields)
         with mock.patch.object(CmisFolder, 'create_value') as mocked:

--- a/cmis_web/i18n/fr.po
+++ b/cmis_web/i18n/fr.po
@@ -236,6 +236,14 @@ msgstr "Veuillez d'abord enregistrer votre objet une première fois."
 
 #. module: cmis_web
 #. openerp-web
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:24
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:36
+#, python-format
+msgid "Created"
+msgstr "Date de création"
+
+#. module: cmis_web
+#. openerp-web
 #: code:addons/cmis_web/static/src/xml/form_widgets.xml:90
 #, python-format
 msgid "Created By"

--- a/cmis_web/i18n/fr.po
+++ b/cmis_web/i18n/fr.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 10.0+e\n"
+"Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-09 17:29+0000\n"
-"PO-Revision-Date: 2017-11-09 17:29+0000\n"
+"POT-Creation-Date: 2019-08-06 13:43+0000\n"
+"PO-Revision-Date: 2019-08-06 13:43+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -15,45 +15,45 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
-#. module: cmis_web_aos
-#. openerp-web
-#: code:addons/cmis_web_aos/static/src/js/office_launcher.js:90
-#, python-format
-msgid " is editing this file. If it's not you any changes you make might be lost."
-msgstr " modifie ce fichier. Si ce  n'est pas vous, tous les changements que vous pourriez faire seront perdus."
-
-
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:68
+#: code:addons/cmis_web/static/src/js/form_widgets.js:124
 #, python-format
 msgid " already exists"
 msgstr " existe déjà"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:939
+#: code:addons/cmis_web/static/src/js/form_widgets.js:997
 #, python-format
 msgid "(filtered from _MAX_ total entries)"
 msgstr "(filtré de _MAX_ éléments au total)"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:954
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1012
 #, python-format
 msgid ": activate to sort column ascending"
 msgstr ": activer pour trier la colonne par ordre croissant"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:955
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1013
 #, python-format
 msgid ": activate to sort column descending"
 msgstr ": activer pour trier la colonne par ordre décroissant"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:212
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1375
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1537
+#, python-format
+msgid "A document with the same name already exists."
+msgstr "Un document avec le même nom existe déjà."
+
+#. module: cmis_web
+#. openerp-web
+#: code:addons/cmis_web/static/src/js/form_widgets.js:268
 #, python-format
 msgid "Add"
 msgstr "Ajouter"
@@ -67,16 +67,24 @@ msgstr "Ajouter un document"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:199
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:216
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:299
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1378
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1540
+#, python-format
+msgid "Alfresco Error"
+msgstr "Erreur Alfresco"
+
+#. module: cmis_web
+#. openerp-web
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:220
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:237
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:333
 #, python-format
 msgid "Browse&hellip;"
 msgstr "Parcourir&hellip;"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:481
+#: code:addons/cmis_web/static/src/js/form_widgets.js:537
 #: code:addons/cmis_web/static/src/xml/form_widgets.xml:105
 #, python-format
 msgid "By:"
@@ -84,108 +92,116 @@ msgstr "Par:"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:606
+#: code:addons/cmis_web/static/src/js/form_widgets.js:663
 #, python-format
 msgid "CMIS Backend Config Error"
 msgstr "CMIS Backend Config Error"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:679
+#: code:addons/cmis_web/static/src/js/form_widgets.js:736
 #, python-format
 msgid "CMIS Error"
 msgstr "Erreur CMIS"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:673
+#: code:addons/cmis_web/static/src/js/form_widgets.js:730
 #, python-format
 msgid "CMIS Error "
 msgstr "Erreur CMIS"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:52
+#: code:addons/cmis_web/static/src/js/form_widgets.js:53
+#: code:addons/cmis_web/static/src/js/form_widgets.js:108
 #, python-format
 msgid "Cancel"
 msgstr "Annuler"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:181
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:202
 #, python-format
 msgid "Cancel Edit"
 msgstr "Annuler l'édition"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:326
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:360
 #, python-format
 msgid "Click here to see more technical info"
 msgstr "Cliquez ici pour voir les détails techniques"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:173
-#: code:addons/cmis_web/static/src/js/form_widgets.js:221
-#: code:addons/cmis_web/static/src/js/form_widgets.js:295
+#: code:addons/cmis_web/static/src/js/form_widgets.js:229
+#: code:addons/cmis_web/static/src/js/form_widgets.js:277
+#: code:addons/cmis_web/static/src/js/form_widgets.js:351
 #, python-format
 msgid "Close"
 msgstr "Fermer"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:899
+#: code:addons/cmis_web/static/src/js/form_widgets.js:957
 #, python-format
 msgid "Columns"
 msgstr "Colonnes"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:242
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:283
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:263
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:304
 #, python-format
 msgid "Comment"
 msgstr "Commentaire"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:1309
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1563
 #, python-format
 msgid "Confirm deletion of "
 msgstr "Veuillez confirmer la suppression de "
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:165
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:194
+#, python-format
+msgid "Copy"
+msgstr "Copier"
+
+#. module: cmis_web
+#. openerp-web
+#: code:addons/cmis_web/static/src/js/form_widgets.js:221
 #, python-format
 msgid "Create"
 msgstr "Créer"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:233
+#: code:addons/cmis_web/static/src/js/form_widgets.js:289
 #, python-format
 msgid "Create Documents "
 msgstr "Ajouter un/des documents"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:180
+#: code:addons/cmis_web/static/src/js/form_widgets.js:236
 #, python-format
 msgid "Create Folder "
 msgstr "Ajouter un répertoire"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:235
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:256
 #, python-format
 msgid "Create a new major version"
 msgstr "Créer une nouvelle version majeure"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:269
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:290
 #, python-format
 msgid "Create a new version"
 msgstr "Créer une nouvelle version"
@@ -206,14 +222,14 @@ msgstr "Créer le répertoire dans la GED"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:229
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:250
 #, python-format
 msgid "Create new minor version"
 msgstr "Créer une nouvelle version mineure"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:847
+#: code:addons/cmis_web/static/src/js/form_widgets.js:905
 #, python-format
 msgid "Create your object first"
 msgstr "Veuillez d'abord enregistrer votre objet une première fois."
@@ -234,7 +250,14 @@ msgstr "Date de création"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:185
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:195
+#, python-format
+msgid "Cut"
+msgstr "Couper"
+
+#. module: cmis_web
+#. openerp-web
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:206
 #, python-format
 msgid "Delete"
 msgstr "Supprimer"
@@ -250,36 +273,36 @@ msgstr "Description"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:153
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:169
 #, python-format
 msgid "Download"
 msgstr "Télécharger"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:948
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1006
 #, python-format
 msgid "First"
 msgstr "Premier"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:313
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:347
 #, python-format
 msgid "Folder Name:"
 msgstr "Nom du répertoire:"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:376
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:180
+#: code:addons/cmis_web/static/src/js/form_widgets.js:432
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:201
 #, python-format
 msgid "Import new version"
 msgstr "Importer une nouvelle version"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:377
+#: code:addons/cmis_web/static/src/js/form_widgets.js:433
 #, python-format
 msgid "Import new version of "
 msgstr "Importer une nouvelle version de "
@@ -293,7 +316,7 @@ msgstr "Verrouillé"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:949
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1007
 #, python-format
 msgid "Last"
 msgstr "Dernier"
@@ -314,7 +337,7 @@ msgstr "Date de dernière modification"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:943
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1001
 #, python-format
 msgid "Loading..."
 msgstr "Chargement en cours..."
@@ -328,14 +351,14 @@ msgstr "MIME Type"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:277
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:298
 #, python-format
 msgid "Major"
 msgstr "Majeure"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:276
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:297
 #, python-format
 msgid "Minor"
 msgstr "Mineure"
@@ -358,7 +381,7 @@ msgstr "Modifié par"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:173
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:189
 #, python-format
 msgid "More actions"
 msgstr "Actions supplémentaires"
@@ -374,35 +397,35 @@ msgstr "Nom"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:950
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:317
 #, python-format
-msgid "New name"
-msgstr "Nouveau nom"
+msgid "New name:"
+msgstr "Nouveau nom:"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:950
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1008
 #, python-format
 msgid "Next"
 msgstr "Suivant"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:936
+#: code:addons/cmis_web/static/src/js/form_widgets.js:994
 #, python-format
 msgid "No data available in table"
 msgstr "Aucun élément à afficher"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:946
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1004
 #, python-format
 msgid "No matching records found"
 msgstr "Aucune donnée disponible"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:281
+#: code:addons/cmis_web/static/src/js/form_widgets.js:337
 #, python-format
 msgid "OK"
 msgstr "OK"
@@ -423,35 +446,45 @@ msgstr "Type de contenu"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:182
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:203
 #, python-format
 msgid "Offline Edit"
 msgstr "Editer hors ligne"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:162
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:146
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:154
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:196
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:197
+#, python-format
+msgid "Paste"
+msgstr "Coller"
+
+#. module: cmis_web
+#. openerp-web
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:178
 #, python-format
 msgid "Preview"
 msgstr "Prévisualiser"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:951
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1009
 #, python-format
 msgid "Previous"
 msgstr "Précédent"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:43
+#: code:addons/cmis_web/static/src/js/form_widgets.js:99
 #, python-format
 msgid "Process"
 msgstr "Exécuter"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:944
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1002
 #, python-format
 msgid "Processing..."
 msgstr "Traitement en cours..."
@@ -465,49 +498,51 @@ msgstr "Rafraichir le contenu de la table"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:257
-#, python-format
-msgid "Rename as"
-msgstr "Renommer en"
-
-#. module: cmis_web
-#. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:257
+#: code:addons/cmis_web/static/src/js/form_widgets.js:44
+#: code:addons/cmis_web/static/src/js/form_widgets.js:66
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:193
 #, python-format
 msgid "Rename"
 msgstr "Renommer"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:1459
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:278
+#, python-format
+msgid "Rename as"
+msgstr "Renommer en"
+
+#. module: cmis_web
+#. openerp-web
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1713
 #, python-format
 msgid "Root"
 msgstr "Racine"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:945
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1003
 #, python-format
 msgid "Search:"
 msgstr "Recherche:"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:942
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1000
 #, python-format
 msgid "Show _MENU_ entries"
 msgstr "Afficher _MENU_ éléments"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:938
+#: code:addons/cmis_web/static/src/js/form_widgets.js:996
 #, python-format
 msgid "Showing 0 to 0 of 0 entries"
 msgstr "Affichage de l'élément 0 à 0 sur 0 élément"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:937
+#: code:addons/cmis_web/static/src/js/form_widgets.js:995
 #, python-format
 msgid "Showing _START_ to _END_ of _TOTAL_ entries"
 msgstr "Affichage de l'élément _START_ à _END_ sur _TOTAL_ éléments"
@@ -523,21 +558,21 @@ msgstr "Titre"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:177
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:198
 #, python-format
 msgid "Update"
 msgstr "Mettre à jour"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:352
+#: code:addons/cmis_web/static/src/js/form_widgets.js:408
 #, python-format
 msgid "Update content"
 msgstr "Mettre à jour le contenu"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:353
+#: code:addons/cmis_web/static/src/js/form_widgets.js:409
 #, python-format
 msgid "Update content of "
 msgstr "Mise à jour du contenu de "
@@ -551,7 +586,8 @@ msgstr "Version"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:176
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:192
 #, python-format
 msgid "View Details"
 msgstr "Afficher les détails"
+

--- a/cmis_web/static/src/js/form_widgets.js
+++ b/cmis_web/static/src/js/form_widgets.js
@@ -476,6 +476,7 @@
        this.title = this.getSuccinctProperty('cm:title', cmis_object) || '';
        this.description = this.getSuccinctProperty('cmis:description', cmis_object);
        this.lastModificationDate = this.getSuccinctProperty('cmis:lastModificationDate', cmis_object);
+       this.creationDate = this.getSuccinctProperty('cmis:creationDate', cmis_object);
        this.lastModifiedBy = this.getSuccinctProperty('cmis:lastModifiedBy', cmis_object);
        this.objectId = this.getSuccinctProperty('cmis:objectId', cmis_object);
        this.versionSeriesId = this.getSuccinctProperty('cmis:versionSeriesId', cmis_object);
@@ -548,6 +549,15 @@
    fLastModificationDate: function() {
        return this.format_cmis_timestamp(this.lastModificationDate);
    },
+
+   /**
+    * Format cmis object creation date
+    * @returns the cmis:creationDate formatted to be rendered in a datatable cell
+    *
+    **/
+   fCreationDate: function() {
+        return this.format_cmis_timestamp(this.creationDate);
+    },
 
    fDetails: function(){
      return '<div class="fa fa-plus-circle"/>'  ;
@@ -978,6 +988,11 @@ var CmisMixin = {
                     width:'120px'
                 },
                 {
+                    data:'fCreationDate()',
+                    width:'120px',
+                    visible: false,
+                },
+                {
                     data: 'lastModifiedBy',
                     width:'60px',
                     visible: false,
@@ -1137,6 +1152,9 @@ var CmisMixin = {
                 orders_by.push('cmis:lastModificationDate ' + sort_order);
                 break;
             case 5:
+                orders_by.push('cmis:creationDate ' + sort_order);
+                break;
+            case 6:
                 orders_by.push('cmis:lastModifiedBy ' + sort_order);
                 break;
             }

--- a/cmis_web/static/src/js/form_widgets.js
+++ b/cmis_web/static/src/js/form_widgets.js
@@ -11,10 +11,7 @@
 
  var core = require('web.core');
  var formWidget = require('web.form_widgets');
- var data = require('web.data');
  var time = require('web.time');
- var ProgressBar = require('web.ProgressBar');
- var Registry = require('web.Registry');
  var Dialog = require('web.Dialog');
  var framework = require('web.framework');
  var DocumentViewer = require('cmis_web.DocumentViewer')

--- a/cmis_web/static/src/js/form_widgets.js
+++ b/cmis_web/static/src/js/form_widgets.js
@@ -129,6 +129,11 @@
          this.$new_filename.val(this.new_filename);
      },
 
+     escape_query_param: function(param){
+       param = param.replace(new RegExp("'", "g"), "\\'");
+       return param;
+     },
+
      /**
         * Method called between @see init and @see start. Performs asynchronous
         * calls required by the rendering and the start method.
@@ -144,7 +149,7 @@
          this.cmis_session.query('' +
              "SELECT cmis:name FROM cmis:document WHERE " +
              "IN_FOLDER('" +  this.parent_cmisobject.objectId +
-             "') AND cmis:name like '" + name_without_ext + "-%." + ext + "'")
+             "') AND cmis:name like '" + self.escape_query_param(name_without_ext) + "-%." + ext + "'")
              .ok(function(data){
                  var cpt = data.results.length;
                  var filenames = _.map(
@@ -170,7 +175,7 @@
          this.cmis_session.query('' +
              "SELECT cmis:objectId FROM cmis:document WHERE " +
              "IN_FOLDER('" +  this.parent_cmisobject.objectId +
-             "') AND cmis:name = '" + this.file.name + "'")
+             "') AND cmis:name = '" + self.escape_query_param(this.file.name) + "'")
              .ok(function(data){
                  self.original_objectId = data.results[0].succinctProperties['cmis:objectId'];
                  dfd2.resolve();

--- a/cmis_web/static/src/js/form_widgets.js
+++ b/cmis_web/static/src/js/form_widgets.js
@@ -18,6 +18,7 @@
  var Dialog = require('web.Dialog');
  var framework = require('web.framework');
  var DocumentViewer = require('cmis_web.DocumentViewer')
+ var crash_manager = require('web.crash_manager');
  
  var _t = core._t;
  var QWeb = core.qweb;
@@ -573,6 +574,7 @@
            ctx[actionName] = value;
        });
        ctx['canPreview'] = ctx['canGetContentStream']; // && this.mimetype === 'application/pdf';
+       ctx['isFolder'] = this.baseTypeId == 'cmis:folder';
        return QWeb.render("CmisContentActions", ctx);
    },
 
@@ -786,6 +788,8 @@ var CmisMixin = {
         this.on('cmis_node_content_updated', this, this.on_cmis_node_content_updated);
         this.on('wrapped_cmis_node_reloaded', this, this.on_wrapped_cmis_node_reloaded);
         this.backend = this.field_manager.get_field_desc(this.name).backend;
+        this.clipboardAction = undefined;
+        this.clipboardObject = undefined;
     },
 
     start: function () {
@@ -796,7 +800,6 @@ var CmisMixin = {
             return;
         }
         this.view.on("change:actual_mode", this, this.on_mode_change);
-
         // refresh the displayed forlder on reload.
         this.getParent().on('load_record', this, this.reload_displayed_folder);
 
@@ -1163,12 +1166,32 @@ var CmisMixin = {
                  self.upload_files(e.originalEvent.dataTransfer.files);
 
              });
-         }
-         /* some UI fixes */
-         this.$el.find('.dropdown-toggle').off('click');
-         this.$el.find('.dropdown-toggle').on('click', function (e){
-             self.dropdown_fix_position($(e.target));
-         });
+        }
+        /* some UI fixes */
+        this.$el.find('.dropdown-toggle').off('click');
+        this.$el.find('.dropdown-toggle').on('click', function (e){
+            self.dropdown_fix_position($(e.target));
+        });
+        this.$el.find('.content-action-cut').on('click', function (e) {
+            self._prevent_on_hashchange(e);
+            var row = self._get_event_row(e);
+            self.on_click_cut(row);
+        });
+        this.$el.find('.content-action-copy').on('click', function (e) {
+            self._prevent_on_hashchange(e);
+            var row = self._get_event_row(e);
+            self.on_click_copy(row);
+        });
+        this.$el.find('.content-action-copy-paste').on('click', function (e) {
+            self._prevent_on_hashchange(e);
+            var row = self._get_event_row(e);
+            self.on_click_copy_paste(row);
+        });
+        this.$el.find('.content-action-cut-paste').on('click', function (e) {
+            self._prevent_on_hashchange(e);
+            var row = self._get_event_row(e);
+            self.on_click_cut_paste(row);
+        });
 
          this.$el.find('.dropdown-menu').off('mouseleave');
          // hide the dropdown menu on mouseleave
@@ -1308,7 +1331,6 @@ var CmisMixin = {
     refresh_datatable: function(paging) {
         this.datatable.draw(paging || 'page');
     },
-
     /**
      * Method called when a root folder is initialized
      */
@@ -1322,12 +1344,122 @@ var CmisMixin = {
         this.$el.find('.root-content-action-new-folder').on('click', function(e){
             var dialog = new CmisCreateFolderDialog(self, self.dislayed_folder_cmisobject);
             dialog.open();
-
+        });
+        this.$el.find('.root-content-action-copy-paste').on('click', function (e) {
+            self.get_new_filename(self.clipboardObject.name, self.displayed_folder_id
+            ).done(function (result) {
+                self.cmis_session.createDocumentFromSource(
+                    self.displayed_folder_id, self.clipboardObject.objectId,
+                    undefined, result
+                ).ok(function (result) {
+                    self.clear_clipboard();
+                    self.reload_displayed_folder();
+                }).notOk(function (error) {
+                    self.clear_clipboard();
+                    self.reload_displayed_folder();
+                });
+            });
+        });
+        this.$el.find('.root-content-action-cut-paste').on('click', function (e) {
+            self.get_new_filename(self.clipboardObject.name, self.displayed_folder_id
+            ).done(function (result) {
+                self.cmis_session.moveObject(
+                    self.clipboardObject.objectId,
+                    self.clipboardFolder,
+                    self.displayed_folder_id
+                ).ok(function (result) {
+                    self.clear_clipboard();
+                    self.reload_displayed_folder();
+                }).notOk(function (error) {
+                    if (error.body.message.startsWith("Duplicate child name not allowed")) {
+                        Dialog.alert(self, _t('A document with the same name already exists.'));
+                    } else {
+                        crash_manager.show_error({
+                            type: _t("Alfresco Error"),
+                            message: error.body.message,
+                            data: {debug: JSON.stringify(error)},
+                        });
+                    }
+                });
+            });
         });
         this.$el.find('.root-content-action-new-doc').on('click', function(e){
             var dialog = new CmisCreateDocumentDialog(self, self.dislayed_folder_cmisobject);
             dialog.open();
         });
+    },
+    clear_clipboard: function () {
+            this.clipboardObject = undefined;
+            this.clipboardAction = undefined;
+            this.clipboardFolder = undefined;
+        },
+
+    /**
+     * Method returning a deferred with true if the filename we want
+     * to copy (or cut) already exists in the folder
+     */
+    filename_already_exists: function (filename, folder) {
+        var self = this;
+        var deferred = $.Deferred();
+        self.cmis_session.query('' +
+            "SELECT cmis:name FROM cmis:document WHERE " +
+            "IN_FOLDER('" + folder +
+            "') AND cmis:name like '" + filename + "'")
+            .ok(function (data) {
+                if (data.numItems > 0) {
+                    deferred.resolve(true);
+                } else {
+                    deferred.resolve(false);
+                }
+            })
+            .notOk(function (error) {
+                deferred.reject(error);
+            });
+        return deferred;
+    },
+
+    /**
+     * Method returning a deferred with the new_filename for a copy or cut
+     */
+    get_new_filename: function (filename, folder) {
+        var self = this;
+        return self.filename_already_exists(filename, folder).then(function (result) {
+            if (result) {
+                var new_filename = undefined;
+                var re = /(?:\.([^.]+))?$/;
+                var parts = re.exec(filename);
+                var name_without_ext = filename.slice(0, -parts[1].length - 1);
+                var ext = parts[1];
+                var deferred = $.Deferred();
+                self.cmis_session.query('' +
+                    "SELECT cmis:name FROM cmis:document WHERE " +
+                    "IN_FOLDER('" + folder +
+                    "') AND cmis:name like '" + name_without_ext.replace(new RegExp("'", "g"), "\\'") + "-%." + ext + "'"
+                    ).ok(function (data) {
+                        var cpt = data.results.length;
+                        var filenames = _.map(
+                            data.results,
+                            function (item) {
+                                return item.succinctProperties['cmis:name'][0];
+                            });
+                        while (true) {
+                            new_filename = name_without_ext + '-' +
+                                cpt + '.' + ext;
+                            if (_.contains(filenames, new_filename)) {
+                                cpt += 1;
+                            } else {
+                                break;
+                            }
+                        }
+                        deferred.resolve(new_filename);
+                    }).notOk(function (error) {
+                        deferred.reject(error);
+                    });
+                return deferred;
+            } else {
+                return filename;
+            }
+        })
     },
 
     /**
@@ -1352,9 +1484,66 @@ var CmisMixin = {
         var documentViewer = new DocumentViewer(this, cmisObjectWrapped, this.datatable.data());
         documentViewer.appendTo($('body'));
     },
-
+    
     on_click_get_properties: function(row){
         this.display_row_details(row);
+    },
+    
+    on_click_copy: function (row) {
+        this.clipboardAction = 'copy';
+        this.clipboardObject = row.data();
+        this.reload_displayed_folder();
+    },
+
+    on_click_cut: function (row) {
+        this.clipboardAction = 'cut';
+        this.clipboardObject = row.data();
+        this.clipboardFolder = this.displayed_folder_id;
+        this.reload_displayed_folder();
+    },
+
+    on_click_copy_paste: function (row) {
+        var self = this;
+        var data = row.data();
+        self.get_new_filename(self.clipboardObject.name, data.objectId
+        ).done(function (result) {
+            self.cmis_session.createDocumentFromSource(
+                data.objectId, self.clipboardObject.objectId,
+                undefined, result
+            ).ok(function (result) {
+                self.clear_clipboard();
+                self.reload_displayed_folder();
+            }).notOk(function (error) {
+                self.clear_clipboard();
+                self.reload_displayed_folder();
+            });
+        });
+    },
+
+    on_click_cut_paste: function (row) {
+        var self = this;
+        var data = row.data();
+        self.get_new_filename(self.clipboardObject.name, data.objectId
+        ).done(function (result) {
+            self.cmis_session.moveObject(
+                self.clipboardObject.objectId,
+                self.clipboardFolder,
+                data.objectId
+            ).ok(function (result) {
+                self.clear_clipboard();
+                self.reload_displayed_folder();
+            }).notOk(function (error) {
+                if (error.body.message.startsWith("Duplicate child name not allowed")) {
+                    Dialog.alert(self, _t('A document with the same name already exists.'));
+                } else {
+                    crash_manager.show_error({
+                        type: _t("Alfresco Error"),
+                        message: error.body.message,
+                        data: {debug: JSON.stringify(error)},
+                    });
+                }
+            });
+        });
     },
 
     on_click_rename: function(row){

--- a/cmis_web/static/src/xml/form_widgets.xml
+++ b/cmis_web/static/src/xml/form_widgets.xml
@@ -21,6 +21,7 @@
                 <th>Title</th>
                 <th>Description</th>
                 <th>Modified</th>
+                <th>Created</th>
                 <th>Modifier</th>
                 <th></th>
             </tr>
@@ -32,6 +33,7 @@
                 <th>Title</th>
                 <th>Description</th>
                 <th>Modified</th>
+                <th>Created</th>
                 <th>Modifier</th>
                 <th></th>
             </tr>

--- a/cmis_web/static/src/xml/form_widgets.xml
+++ b/cmis_web/static/src/xml/form_widgets.xml
@@ -138,6 +138,22 @@
                  aria-label="Add document">
              <span class="glyphicon glyphicon-file" aria-hidden="true"></span>
          </button>
+           <button type="button"
+                 t-if="object.clipboardAction == 'copy' &amp; canCreateDocument"
+                 t-attf-class="btn btn-default btn-sm root-content-action-copy-paste"
+                 data-toggle="tooltip"
+                 title="Paste"
+                 aria-label="Paste">
+             <span class="fa fa-paste"></span>
+         </button>
+           <button type="button"
+                 t-if="object.clipboardAction == 'cut' &amp; canCreateDocument"
+                 t-attf-class="btn btn-default btn-sm root-content-action-cut-paste"
+                 data-toggle="tooltip"
+                 title="Paste"
+                 aria-label="Paste">
+             <span class="fa fa-paste"></span>
+         </button>
        </div>
     </div>
 </t>
@@ -146,13 +162,13 @@
     <div class="field_cmis_folder_content_actions">
     <div class="btn-group pull-right" role="group">
         <t t-if='canGetContentStream'>
-          <a type="button"
+          <button type="button"
              class="btn btn-default btn-xs content-action-download"
              aria-label="Download"
              data-toggle="tooltip"
              title="Download">
               <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span>
-          </a>
+          </button>
         </t>
         <t t-if='canPreview'>
           <button type="button"
@@ -163,7 +179,7 @@
               <span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span>
           </button>
         </t>
-            <a type="button"
+            <button type="button"
                class="btn btn-default btn-xs dropdown-toggle glyphicon glyphicon-align-justify"
                t-att-id="object.getSuccinctProperty('cmis:objectId')"
                aria-label="More actions"
@@ -171,10 +187,14 @@
                title="More actions"
                aria-haspopup="true"
                aria-expanded="true">
-            </a>
+            </button>
             <ul class="dropdown-menu btn-block" t-att-aria-labelledby="object.getSuccinctProperty('cmis:objectId')">
                 <li t-if='canGetProperties'><a class='content-action-get-properties' href="#">View Details</a></li>
                 <li t-if='canUpdateProperties'><a class='content-action-rename' href="#">Rename</a></li>
+                <li t-if='!isFolder'><a class='content-action-copy' href="#"><i class="fa fa-copy"></i> Copy</a></li>
+                <li t-if='canMoveObject'><a class='content-action-cut' href="#"><i class="fa fa-cut"></i> Cut</a></li>
+                <li t-if='canCreateDocument &amp; object.parent.clipboardAction == "cut"'><a class='content-action-cut-paste' href="#"><i class="fa fa-paste"></i> Paste</a></li>
+                <li t-if='canCreateDocument &amp; object.parent.clipboardAction == "copy"'><a class='content-action-copy-paste' href="#"><i class="fa fa-paste"></i> Paste</a></li>
                 <li t-if='canSetContentStream and !canCheckIn'><a class='content-action-set-content-stream' href="#">Update</a></li>
                 <!-- li t-if='canGetAllVersions'><a class='content-action-get-all-versions' href="#">Check Versions</a></li -->
                 <li t-if='canCheckIn or canCancelCheckOut or canCheckOut' role="separator" class="divider"></li>

--- a/cmis_web_proxy_alf/controllers/alfresco.py
+++ b/cmis_web_proxy_alf/controllers/alfresco.py
@@ -33,7 +33,7 @@ class AlfrescoProxy(cmis.CmisProxy):
         '/<int:backend_id>'
         '/content/thumbnails/pdf/' +
         '<string:cmis_name>',
-        ], type='http', auth="user", csrf=False, methods=['GET'])
+    ], type='http', auth="user", csrf=False, methods=['GET'])
     @main.serialize_exception
     def get_thumnails(self, backend_id, cmis_name,
                       **kwargs):


### PR DESCRIPTION
- [X]  cmis_field: Prevent error in unique name computation
- [X]  cmis_field: Escape quote char "'" into query
This change fixes an error in the case when a folder with a single quote
into the name was creaed by the backend. 
- [X] cmis_web: Fixes an error in the case when a file with a single quote
into the name was dropped two times in the same folder. Into the second
drop, the logic in charge of processing duplication of content do a cmis
query to check if a document with the same name already exists. The
error occured into this query since the single quote was not escaped.
- [X] cmis_web: cut / copy / paste feature
- [X] cmis_alf: Add method to support folder creation from space-template