### PR TITLE
[9.0] next release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,19 @@
-9.0.4.0.0 (Sep, 11, 218) backported from 10.0.4.0.0
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+9.0.5.0.0 (Oct, 10, 2019)
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* cmis_field: Prevent error in unique name computation
+* cmis_field: Escape quote char "'" into query
+  This change fixes an error in the case when a folder with a single quote
+  into the name was creaed by the backend.
+* cmis_web: Fixes an error in the case when a file with a single quote
+  into the name was dropped two times in the same folder. Into the second
+  drop, the logic in charge of processing duplication of content do a cmis
+  query to check if a document with the same name already exists. The
+  error occured into this query since the single quote was not escaped.
+* cmis_web: cut / copy / paste feature
+
+9.0.4.0.0 (Sep, 11, 2018) backported from 10.0.4.0.0
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Fix: cmis_web: clear rows before reloading the table to avoid error if an
   expanded row is no more into the reloaded info.

--- a/acsoo.cfg
+++ b/acsoo.cfg
@@ -1,3 +1,7 @@
+[flake8]
+flake8-options=
+  --ignore=W503,W504
+
 [pylint]
 pylint-options=
   --disable=locally-disabled,unnecessary-utf8-coding-comment

--- a/cmis_field/models/cmis_backend.py
+++ b/cmis_field/models/cmis_backend.py
@@ -169,6 +169,7 @@ class CmisBackend(models.Model):
                         num = re.findall(r'_\((\d+)\)', n)
                         if num:
                             nums.append(int(num[0]))
-                    max_num = max(nums)
+                    if nums:
+                        max_num = max(nums)
                 return name + '_(%d)' % (max_num + 1)
         return name

--- a/cmis_field/models/cmis_backend.py
+++ b/cmis_field/models/cmis_backend.py
@@ -159,7 +159,8 @@ class CmisBackend(models.Model):
                 testname = name + '_(%)'
                 cmis_qry = ("SELECT * FROM cmis:folder WHERE "
                             "IN_FOLDER('%s') AND cmis:name like '%s'" %
-                            (parent.getObjectId(), testname))
+                            (parent.getObjectId(),
+                             testname.replace("'", "\\'")))
                 rs = parent.repository.query(cmis_qry)
                 names = [r.name for r in rs]
                 max_num = 0

--- a/cmis_field/models/cmis_backend.py
+++ b/cmis_field/models/cmis_backend.py
@@ -22,7 +22,7 @@ class CmisBackend(models.Model):
                 raise ValidationError(
                     _("The character to use as replacement can not be one of"
                       "'%s'") % CMIS_NAME_INVALID_CHARS
-                    )
+                )
 
     enable_sanitize_cmis_name = fields.Boolean(
         'Sanitize name on content creation?',

--- a/cmis_field/models/cmis_backend.py
+++ b/cmis_field/models/cmis_backend.py
@@ -148,7 +148,7 @@ class CmisBackend(models.Model):
                             self.folder_name_conflict_handler)
         cmis_qry = ("SELECT cmis:objectId FROM cmis:folder WHERE "
                     "IN_FOLDER('%s') AND cmis:name='%s'" %
-                    (parent.getObjectId(), name))
+                    (parent.getObjectId(), name.replace("'", "\\'")))
         rs = parent.repository.query(cmis_qry)
         num_found_items = rs.getNumItems()
         if num_found_items > 0:

--- a/cmis_field/models/cmis_backend.py
+++ b/cmis_field/models/cmis_backend.py
@@ -164,7 +164,11 @@ class CmisBackend(models.Model):
                 names = [r.name for r in rs]
                 max_num = 0
                 if names:
-                    max_num = max(
-                        [int(re.findall(r'_\((\d+)\)', n)[-1]) for n in names])
+                    nums = []
+                    for n in names:
+                        num = re.findall(r'_\((\d+)\)', n)
+                        if num:
+                            nums.append(int(num[0]))
+                    max_num = max(nums)
                 return name + '_(%d)' % (max_num + 1)
         return name

--- a/cmis_field/tests/test_cmis_backend.py
+++ b/cmis_field/tests/test_cmis_backend.py
@@ -89,7 +89,7 @@ class TestCmisBackend(common.SavepointCase):
                 test = mock.Mock()
                 test.configure_mock()
                 ret = []
-                for v in ['test_(1)', 'test_(3)']:
+                for v in ['test_(backup)', 'test_(1)', 'test_(3)']:
                     m = mock.Mock()
                     m.configure_mock(name=v)
                     ret.append(m)

--- a/cmis_field/tests/test_cmis_backend.py
+++ b/cmis_field/tests/test_cmis_backend.py
@@ -95,7 +95,7 @@ class TestCmisBackend(common.SavepointCase):
                     ret.append(m)
                 query_result.__iter__.return_value = ret
                 return query_result
-            return None
+            return None  # pragma: no cover
         # if the same name is found and the folder_name_conflict_handler ==
         # 'increment' the method must return a new name with a suffix _(X)
         # where X is the value max found as X for the same name + 1
@@ -104,3 +104,48 @@ class TestCmisBackend(common.SavepointCase):
         name = self.backend_instance.get_unique_folder_name(
             'test', mocked_parent)
         self.assertEqual('test_(4)', name)
+
+    def test_get_unique_folder_name_2(self):
+        mocked_parent = mock.MagicMock()
+        # if no name found, the method return the same name
+        repository = mock.MagicMock()
+        mocked_parent.repository = repository
+        query_result = mock.MagicMock()
+        repository.query.side_effect = lambda *a: query_result
+        query_result.getNumItems.side_effect = lambda *a: 0
+        self.assertEqual('test', self.backend_instance.get_unique_folder_name(
+            'test', mocked_parent))
+        # if the same name is found and the folder_name_conflict_handler ==
+        # 'error' a ValidationError is raised
+        query_result.getNumItems.side_effect = lambda *a: 1
+        self.backend_instance.folder_name_conflict_handler = 'error'
+        with self.assertRaises(ValidationError):
+            self.backend_instance.get_unique_folder_name('test', mocked_parent)
+
+        self.cpt = 0
+
+        # in this case a name is found put without increment
+        def query(q):
+            if self.cpt == 0:
+                self.cpt += 1
+                query_result.getNumItems.side_effect = lambda *a: 1
+                return query_result
+            if self.cpt == 1:
+                test = mock.Mock()
+                test.configure_mock()
+                ret = []
+                for v in ['test_(backup)']:
+                    m = mock.Mock()
+                    m.configure_mock(name=v)
+                    ret.append(m)
+                query_result.__iter__.return_value = ret
+                return query_result
+            return None  # pragma: no cover
+        # if no name is found and the folder_name_conflict_handler ==
+        # 'increment' the method must return a new name with a suffix _(X)
+        # where X is the value max found as X for the same name + 1
+        self.backend_instance.folder_name_conflict_handler = 'increment'
+        repository.query.side_effect = query
+        name = self.backend_instance.get_unique_folder_name(
+            'test', mocked_parent)
+        self.assertEqual('test_(1)', name)

--- a/cmis_field/tests/test_ir_model_fields.py
+++ b/cmis_field/tests/test_ir_model_fields.py
@@ -23,7 +23,7 @@ class TestIrModelFields(BaseTestCmis):
             'name': x_field,
             'model': 'res.company',
             'model_id': model_id,
-            })
+        })
         ir_model_fields = self.env['ir.model.fields']
         self.assertTrue(x_field in res_company._fields)
         with mock.patch.object(CmisFolder, 'create_value') as mocked:

--- a/cmis_web/i18n/fr.po
+++ b/cmis_web/i18n/fr.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 10.0+e\n"
+"Project-Id-Version: Odoo Server 9.0c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-09 17:29+0000\n"
-"PO-Revision-Date: 2017-11-09 17:29+0000\n"
+"POT-Creation-Date: 2019-08-06 14:40+0000\n"
+"PO-Revision-Date: 2019-08-06 14:40+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -15,45 +15,45 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
-#. module: cmis_web_aos
-#. openerp-web
-#: code:addons/cmis_web_aos/static/src/js/office_launcher.js:90
-#, python-format
-msgid " is editing this file. If it's not you any changes you make might be lost."
-msgstr " modifie ce fichier. Si ce  n'est pas vous, tous les changements que vous pourriez faire seront perdus."
-
-
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:68
+#: code:addons/cmis_web/static/src/js/form_widgets.js:126
 #, python-format
 msgid " already exists"
 msgstr " existe déjà"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:939
+#: code:addons/cmis_web/static/src/js/form_widgets.js:999
 #, python-format
 msgid "(filtered from _MAX_ total entries)"
 msgstr "(filtré de _MAX_ éléments au total)"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:954
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1014
 #, python-format
 msgid ": activate to sort column ascending"
 msgstr ": activer pour trier la colonne par ordre croissant"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:955
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1015
 #, python-format
 msgid ": activate to sort column descending"
 msgstr ": activer pour trier la colonne par ordre décroissant"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:212
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1377
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1539
+#, python-format
+msgid "A document with the same name already exists."
+msgstr "Un document avec le même nom existe déjà."
+
+#. module: cmis_web
+#. openerp-web
+#: code:addons/cmis_web/static/src/js/form_widgets.js:270
 #, python-format
 msgid "Add"
 msgstr "Ajouter"
@@ -67,16 +67,24 @@ msgstr "Ajouter un document"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:199
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:216
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:299
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1380
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1542
+#, python-format
+msgid "Alfresco Error"
+msgstr "Erreur Alfresco"
+
+#. module: cmis_web
+#. openerp-web
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:220
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:237
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:333
 #, python-format
 msgid "Browse&hellip;"
 msgstr "Parcourir&hellip;"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:481
+#: code:addons/cmis_web/static/src/js/form_widgets.js:539
 #: code:addons/cmis_web/static/src/xml/form_widgets.xml:105
 #, python-format
 msgid "By:"
@@ -84,108 +92,116 @@ msgstr "Par:"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:606
+#: code:addons/cmis_web/static/src/js/form_widgets.js:665
 #, python-format
 msgid "CMIS Backend Config Error"
 msgstr "CMIS Backend Config Error"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:679
+#: code:addons/cmis_web/static/src/js/form_widgets.js:738
 #, python-format
 msgid "CMIS Error"
 msgstr "Erreur CMIS"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:673
+#: code:addons/cmis_web/static/src/js/form_widgets.js:732
 #, python-format
 msgid "CMIS Error "
 msgstr "Erreur CMIS"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:52
+#: code:addons/cmis_web/static/src/js/form_widgets.js:55
+#: code:addons/cmis_web/static/src/js/form_widgets.js:110
 #, python-format
 msgid "Cancel"
 msgstr "Annuler"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:181
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:202
 #, python-format
 msgid "Cancel Edit"
 msgstr "Annuler l'édition"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:326
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:360
 #, python-format
 msgid "Click here to see more technical info"
 msgstr "Cliquez ici pour voir les détails techniques"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:173
-#: code:addons/cmis_web/static/src/js/form_widgets.js:221
-#: code:addons/cmis_web/static/src/js/form_widgets.js:295
+#: code:addons/cmis_web/static/src/js/form_widgets.js:231
+#: code:addons/cmis_web/static/src/js/form_widgets.js:279
+#: code:addons/cmis_web/static/src/js/form_widgets.js:353
 #, python-format
 msgid "Close"
 msgstr "Fermer"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:899
+#: code:addons/cmis_web/static/src/js/form_widgets.js:959
 #, python-format
 msgid "Columns"
 msgstr "Colonnes"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:242
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:283
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:263
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:304
 #, python-format
 msgid "Comment"
 msgstr "Commentaire"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:1309
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1565
 #, python-format
 msgid "Confirm deletion of "
 msgstr "Veuillez confirmer la suppression de "
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:165
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:194
+#, python-format
+msgid "Copy"
+msgstr "Copier"
+
+#. module: cmis_web
+#. openerp-web
+#: code:addons/cmis_web/static/src/js/form_widgets.js:223
 #, python-format
 msgid "Create"
 msgstr "Créer"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:233
+#: code:addons/cmis_web/static/src/js/form_widgets.js:291
 #, python-format
 msgid "Create Documents "
 msgstr "Ajouter un/des documents"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:180
+#: code:addons/cmis_web/static/src/js/form_widgets.js:238
 #, python-format
 msgid "Create Folder "
 msgstr "Ajouter un répertoire"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:235
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:256
 #, python-format
 msgid "Create a new major version"
 msgstr "Créer une nouvelle version majeure"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:269
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:290
 #, python-format
 msgid "Create a new version"
 msgstr "Créer une nouvelle version"
@@ -206,14 +222,14 @@ msgstr "Créer le répertoire dans la GED"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:229
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:250
 #, python-format
 msgid "Create new minor version"
 msgstr "Créer une nouvelle version mineure"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:847
+#: code:addons/cmis_web/static/src/js/form_widgets.js:907
 #, python-format
 msgid "Create your object first"
 msgstr "Veuillez d'abord enregistrer votre objet une première fois."
@@ -234,7 +250,14 @@ msgstr "Date de création"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:185
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:195
+#, python-format
+msgid "Cut"
+msgstr "Couper"
+
+#. module: cmis_web
+#. openerp-web
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:206
 #, python-format
 msgid "Delete"
 msgstr "Supprimer"
@@ -250,36 +273,36 @@ msgstr "Description"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:153
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:169
 #, python-format
 msgid "Download"
 msgstr "Télécharger"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:948
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1008
 #, python-format
 msgid "First"
 msgstr "Premier"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:313
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:347
 #, python-format
 msgid "Folder Name:"
 msgstr "Nom du répertoire:"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:376
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:180
+#: code:addons/cmis_web/static/src/js/form_widgets.js:434
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:201
 #, python-format
 msgid "Import new version"
 msgstr "Importer une nouvelle version"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:377
+#: code:addons/cmis_web/static/src/js/form_widgets.js:435
 #, python-format
 msgid "Import new version of "
 msgstr "Importer une nouvelle version de "
@@ -293,7 +316,7 @@ msgstr "Verrouillé"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:949
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1009
 #, python-format
 msgid "Last"
 msgstr "Dernier"
@@ -314,7 +337,7 @@ msgstr "Date de dernière modification"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:943
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1003
 #, python-format
 msgid "Loading..."
 msgstr "Chargement en cours..."
@@ -328,14 +351,14 @@ msgstr "MIME Type"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:277
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:298
 #, python-format
 msgid "Major"
 msgstr "Majeure"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:276
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:297
 #, python-format
 msgid "Minor"
 msgstr "Mineure"
@@ -358,7 +381,7 @@ msgstr "Modifié par"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:173
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:189
 #, python-format
 msgid "More actions"
 msgstr "Actions supplémentaires"
@@ -374,35 +397,35 @@ msgstr "Nom"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:950
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:317
 #, python-format
-msgid "New name"
-msgstr "Nouveau nom"
+msgid "New name:"
+msgstr "Nouveau nom:"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:950
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1010
 #, python-format
 msgid "Next"
 msgstr "Suivant"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:936
+#: code:addons/cmis_web/static/src/js/form_widgets.js:996
 #, python-format
 msgid "No data available in table"
 msgstr "Aucun élément à afficher"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:946
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1006
 #, python-format
 msgid "No matching records found"
 msgstr "Aucune donnée disponible"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:281
+#: code:addons/cmis_web/static/src/js/form_widgets.js:339
 #, python-format
 msgid "OK"
 msgstr "OK"
@@ -423,35 +446,45 @@ msgstr "Type de contenu"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:182
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:203
 #, python-format
 msgid "Offline Edit"
 msgstr "Editer hors ligne"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:162
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:146
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:154
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:196
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:197
+#, python-format
+msgid "Paste"
+msgstr "Coller"
+
+#. module: cmis_web
+#. openerp-web
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:178
 #, python-format
 msgid "Preview"
 msgstr "Prévisualiser"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:951
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1011
 #, python-format
 msgid "Previous"
 msgstr "Précédent"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:43
+#: code:addons/cmis_web/static/src/js/form_widgets.js:101
 #, python-format
 msgid "Process"
 msgstr "Exécuter"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:944
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1004
 #, python-format
 msgid "Processing..."
 msgstr "Traitement en cours..."
@@ -465,49 +498,51 @@ msgstr "Rafraichir le contenu de la table"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:257
-#, python-format
-msgid "Rename as"
-msgstr "Renommer en"
-
-#. module: cmis_web
-#. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:257
+#: code:addons/cmis_web/static/src/js/form_widgets.js:46
+#: code:addons/cmis_web/static/src/js/form_widgets.js:68
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:193
 #, python-format
 msgid "Rename"
 msgstr "Renommer"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:1459
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:278
+#, python-format
+msgid "Rename as"
+msgstr "Renommer en"
+
+#. module: cmis_web
+#. openerp-web
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1715
 #, python-format
 msgid "Root"
 msgstr "Racine"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:945
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1005
 #, python-format
 msgid "Search:"
 msgstr "Recherche:"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:942
+#: code:addons/cmis_web/static/src/js/form_widgets.js:1002
 #, python-format
 msgid "Show _MENU_ entries"
 msgstr "Afficher _MENU_ éléments"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:938
+#: code:addons/cmis_web/static/src/js/form_widgets.js:998
 #, python-format
 msgid "Showing 0 to 0 of 0 entries"
 msgstr "Affichage de l'élément 0 à 0 sur 0 élément"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:937
+#: code:addons/cmis_web/static/src/js/form_widgets.js:997
 #, python-format
 msgid "Showing _START_ to _END_ of _TOTAL_ entries"
 msgstr "Affichage de l'élément _START_ à _END_ sur _TOTAL_ éléments"
@@ -523,21 +558,21 @@ msgstr "Titre"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:177
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:198
 #, python-format
 msgid "Update"
 msgstr "Mettre à jour"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:352
+#: code:addons/cmis_web/static/src/js/form_widgets.js:410
 #, python-format
 msgid "Update content"
 msgstr "Mettre à jour le contenu"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/js/form_widgets.js:353
+#: code:addons/cmis_web/static/src/js/form_widgets.js:411
 #, python-format
 msgid "Update content of "
 msgstr "Mise à jour du contenu de "
@@ -551,7 +586,8 @@ msgstr "Version"
 
 #. module: cmis_web
 #. openerp-web
-#: code:addons/cmis_web/static/src/xml/form_widgets.xml:176
+#: code:addons/cmis_web/static/src/xml/form_widgets.xml:192
 #, python-format
 msgid "View Details"
 msgstr "Afficher les détails"
+

--- a/cmis_web/static/src/js/form_widgets.js
+++ b/cmis_web/static/src/js/form_widgets.js
@@ -131,6 +131,11 @@
          this.$new_filename.val(this.new_filename);
      },
 
+     escape_query_param: function(param){
+       param = param.replace(new RegExp("'", "g"), "\\'");
+       return param;
+     },
+
      /**
         * Method called between @see init and @see start. Performs asynchronous
         * calls required by the rendering and the start method.
@@ -146,7 +151,7 @@
          this.cmis_session.query('' +
              "SELECT cmis:name FROM cmis:document WHERE " +
              "IN_FOLDER('" +  this.parent_cmisobject.objectId +
-             "') AND cmis:name like '" + name_without_ext + "-%." + ext + "'")
+             "') AND cmis:name like '" + self.escape_query_param(name_without_ext) + "-%." + ext + "'")
              .ok(function(data){
                  var cpt = data.results.length;
                  var filenames = _.map(
@@ -172,7 +177,7 @@
          this.cmis_session.query('' +
              "SELECT cmis:objectId FROM cmis:document WHERE " +
              "IN_FOLDER('" +  this.parent_cmisobject.objectId +
-             "') AND cmis:name = '" + this.file.name + "'")
+             "') AND cmis:name = '" + self.escape_query_param(this.file.name) + "'")
              .ok(function(data){
                  self.original_objectId = data.results[0].succinctProperties['cmis:objectId'];
                  dfd2.resolve();

--- a/cmis_web/static/src/js/form_widgets.js
+++ b/cmis_web/static/src/js/form_widgets.js
@@ -20,7 +20,8 @@
  var _ = require('_');
  var $ = require('$');
  var DocumentViewer = require('cmis_web.DocumentViewer')
-
+ var crash_manager = require('web.crash_manager');
+ 
  var _t = core._t;
  var QWeb = core.qweb;
 
@@ -575,6 +576,7 @@
            ctx[actionName] = value;
        });
        ctx['canPreview'] = ctx['canGetContentStream']; // && this.mimetype === 'application/pdf';
+       ctx['isFolder'] = this.baseTypeId == 'cmis:folder';
        return QWeb.render("CmisContentActions", ctx);
    },
 
@@ -788,6 +790,8 @@ var CmisMixin = {
         this.on('cmis_node_content_updated', this, this.on_cmis_node_content_updated);
         this.on('wrapped_cmis_node_reloaded', this, this.on_wrapped_cmis_node_reloaded);
         this.backend = this.field_manager.get_field_desc(this.name).backend;
+        this.clipboardAction = undefined;
+        this.clipboardObject = undefined;
     },
 
     start: function () {
@@ -798,7 +802,6 @@ var CmisMixin = {
             return;
         }
         this.view.on("change:actual_mode", this, this.on_mode_change);
-
         // refresh the displayed forlder on reload.
         this.getParent().on('load_record', this, this.reload_displayed_folder);
 
@@ -1165,12 +1168,32 @@ var CmisMixin = {
                  self.upload_files(e.originalEvent.dataTransfer.files);
 
              });
-         }
-         /* some UI fixes */
-         this.$el.find('.dropdown-toggle').off('click');
-         this.$el.find('.dropdown-toggle').on('click', function (e){
-             self.dropdown_fix_position($(e.target));
-         });
+        }
+        /* some UI fixes */
+        this.$el.find('.dropdown-toggle').off('click');
+        this.$el.find('.dropdown-toggle').on('click', function (e){
+            self.dropdown_fix_position($(e.target));
+        });
+        this.$el.find('.content-action-cut').on('click', function (e) {
+            self._prevent_on_hashchange(e);
+            var row = self._get_event_row(e);
+            self.on_click_cut(row);
+        });
+        this.$el.find('.content-action-copy').on('click', function (e) {
+            self._prevent_on_hashchange(e);
+            var row = self._get_event_row(e);
+            self.on_click_copy(row);
+        });
+        this.$el.find('.content-action-copy-paste').on('click', function (e) {
+            self._prevent_on_hashchange(e);
+            var row = self._get_event_row(e);
+            self.on_click_copy_paste(row);
+        });
+        this.$el.find('.content-action-cut-paste').on('click', function (e) {
+            self._prevent_on_hashchange(e);
+            var row = self._get_event_row(e);
+            self.on_click_cut_paste(row);
+        });
 
          this.$el.find('.dropdown-menu').off('mouseleave');
          // hide the dropdown menu on mouseleave
@@ -1310,7 +1333,6 @@ var CmisMixin = {
     refresh_datatable: function(paging) {
         this.datatable.draw(paging || 'page');
     },
-
     /**
      * Method called when a root folder is initialized
      */
@@ -1324,12 +1346,122 @@ var CmisMixin = {
         this.$el.find('.root-content-action-new-folder').on('click', function(e){
             var dialog = new CmisCreateFolderDialog(self, self.dislayed_folder_cmisobject);
             dialog.open();
-
+        });
+        this.$el.find('.root-content-action-copy-paste').on('click', function (e) {
+            self.get_new_filename(self.clipboardObject.name, self.displayed_folder_id
+            ).done(function (result) {
+                self.cmis_session.createDocumentFromSource(
+                    self.displayed_folder_id, self.clipboardObject.objectId,
+                    undefined, result
+                ).ok(function (result) {
+                    self.clear_clipboard();
+                    self.reload_displayed_folder();
+                }).notOk(function (error) {
+                    self.clear_clipboard();
+                    self.reload_displayed_folder();
+                });
+            });
+        });
+        this.$el.find('.root-content-action-cut-paste').on('click', function (e) {
+            self.get_new_filename(self.clipboardObject.name, self.displayed_folder_id
+            ).done(function (result) {
+                self.cmis_session.moveObject(
+                    self.clipboardObject.objectId,
+                    self.clipboardFolder,
+                    self.displayed_folder_id
+                ).ok(function (result) {
+                    self.clear_clipboard();
+                    self.reload_displayed_folder();
+                }).notOk(function (error) {
+                    if (error.body.message.startsWith("Duplicate child name not allowed")) {
+                        Dialog.alert(self, _t('A document with the same name already exists.'));
+                    } else {
+                        crash_manager.show_error({
+                            type: _t("Alfresco Error"),
+                            message: error.body.message,
+                            data: {debug: JSON.stringify(error)},
+                        });
+                    }
+                });
+            });
         });
         this.$el.find('.root-content-action-new-doc').on('click', function(e){
             var dialog = new CmisCreateDocumentDialog(self, self.dislayed_folder_cmisobject);
             dialog.open();
         });
+    },
+    clear_clipboard: function () {
+            this.clipboardObject = undefined;
+            this.clipboardAction = undefined;
+            this.clipboardFolder = undefined;
+        },
+
+    /**
+     * Method returning a deferred with true if the filename we want
+     * to copy (or cut) already exists in the folder
+     */
+    filename_already_exists: function (filename, folder) {
+        var self = this;
+        var deferred = $.Deferred();
+        self.cmis_session.query('' +
+            "SELECT cmis:name FROM cmis:document WHERE " +
+            "IN_FOLDER('" + folder +
+            "') AND cmis:name like '" + filename + "'")
+            .ok(function (data) {
+                if (data.numItems > 0) {
+                    deferred.resolve(true);
+                } else {
+                    deferred.resolve(false);
+                }
+            })
+            .notOk(function (error) {
+                deferred.reject(error);
+            });
+        return deferred;
+    },
+
+    /**
+     * Method returning a deferred with the new_filename for a copy or cut
+     */
+    get_new_filename: function (filename, folder) {
+        var self = this;
+        return self.filename_already_exists(filename, folder).then(function (result) {
+            if (result) {
+                var new_filename = undefined;
+                var re = /(?:\.([^.]+))?$/;
+                var parts = re.exec(filename);
+                var name_without_ext = filename.slice(0, -parts[1].length - 1);
+                var ext = parts[1];
+                var deferred = $.Deferred();
+                self.cmis_session.query('' +
+                    "SELECT cmis:name FROM cmis:document WHERE " +
+                    "IN_FOLDER('" + folder +
+                    "') AND cmis:name like '" + name_without_ext.replace(new RegExp("'", "g"), "\\'") + "-%." + ext + "'"
+                    ).ok(function (data) {
+                        var cpt = data.results.length;
+                        var filenames = _.map(
+                            data.results,
+                            function (item) {
+                                return item.succinctProperties['cmis:name'][0];
+                            });
+                        while (true) {
+                            new_filename = name_without_ext + '-' +
+                                cpt + '.' + ext;
+                            if (_.contains(filenames, new_filename)) {
+                                cpt += 1;
+                            } else {
+                                break;
+                            }
+                        }
+                        deferred.resolve(new_filename);
+                    }).notOk(function (error) {
+                        deferred.reject(error);
+                    });
+                return deferred;
+            } else {
+                return filename;
+            }
+        })
     },
 
     /**
@@ -1354,9 +1486,66 @@ var CmisMixin = {
         var documentViewer = new DocumentViewer(this, cmisObjectWrapped, this.datatable.data());
         documentViewer.appendTo($('body'));
     },
-
+    
     on_click_get_properties: function(row){
         this.display_row_details(row);
+    },
+    
+    on_click_copy: function (row) {
+        this.clipboardAction = 'copy';
+        this.clipboardObject = row.data();
+        this.reload_displayed_folder();
+    },
+
+    on_click_cut: function (row) {
+        this.clipboardAction = 'cut';
+        this.clipboardObject = row.data();
+        this.clipboardFolder = this.displayed_folder_id;
+        this.reload_displayed_folder();
+    },
+
+    on_click_copy_paste: function (row) {
+        var self = this;
+        var data = row.data();
+        self.get_new_filename(self.clipboardObject.name, data.objectId
+        ).done(function (result) {
+            self.cmis_session.createDocumentFromSource(
+                data.objectId, self.clipboardObject.objectId,
+                undefined, result
+            ).ok(function (result) {
+                self.clear_clipboard();
+                self.reload_displayed_folder();
+            }).notOk(function (error) {
+                self.clear_clipboard();
+                self.reload_displayed_folder();
+            });
+        });
+    },
+
+    on_click_cut_paste: function (row) {
+        var self = this;
+        var data = row.data();
+        self.get_new_filename(self.clipboardObject.name, data.objectId
+        ).done(function (result) {
+            self.cmis_session.moveObject(
+                self.clipboardObject.objectId,
+                self.clipboardFolder,
+                data.objectId
+            ).ok(function (result) {
+                self.clear_clipboard();
+                self.reload_displayed_folder();
+            }).notOk(function (error) {
+                if (error.body.message.startsWith("Duplicate child name not allowed")) {
+                    Dialog.alert(self, _t('A document with the same name already exists.'));
+                } else {
+                    crash_manager.show_error({
+                        type: _t("Alfresco Error"),
+                        message: error.body.message,
+                        data: {debug: JSON.stringify(error)},
+                    });
+                }
+            });
+        });
     },
 
     on_click_rename: function(row){

--- a/cmis_web/static/src/js/form_widgets.js
+++ b/cmis_web/static/src/js/form_widgets.js
@@ -11,10 +11,7 @@
 
  var core = require('web.core');
  var formWidget = require('web.form_widgets');
- var data = require('web.data');
  var time = require('web.time');
- var ProgressBar = require('web.ProgressBar');
- var Registry = require('web.Registry');
  var Dialog = require('web.Dialog');
  var framework = require('web.framework');
  var _ = require('_');

--- a/cmis_web/static/src/xml/form_widgets.xml
+++ b/cmis_web/static/src/xml/form_widgets.xml
@@ -138,6 +138,22 @@
                  aria-label="Add document">
              <span class="glyphicon glyphicon-file" aria-hidden="true"></span>
          </button>
+           <button type="button"
+                 t-if="object.clipboardAction == 'copy' &amp; canCreateDocument"
+                 t-attf-class="btn btn-default btn-sm root-content-action-copy-paste"
+                 data-toggle="tooltip"
+                 title="Paste"
+                 aria-label="Paste">
+             <span class="fa fa-paste"></span>
+         </button>
+           <button type="button"
+                 t-if="object.clipboardAction == 'cut' &amp; canCreateDocument"
+                 t-attf-class="btn btn-default btn-sm root-content-action-cut-paste"
+                 data-toggle="tooltip"
+                 title="Paste"
+                 aria-label="Paste">
+             <span class="fa fa-paste"></span>
+         </button>
        </div>
     </div>
 </t>
@@ -146,13 +162,13 @@
     <div class="field_cmis_folder_content_actions">
     <div class="btn-group pull-right" role="group">
         <t t-if='canGetContentStream'>
-          <a type="button"
+          <button type="button"
              class="btn btn-default btn-xs content-action-download"
              aria-label="Download"
              data-toggle="tooltip"
              title="Download">
               <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span>
-          </a>
+          </button>
         </t>
         <t t-if='canPreview'>
           <button type="button"
@@ -163,7 +179,7 @@
               <span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span>
           </button>
         </t>
-            <a type="button"
+            <button type="button"
                class="btn btn-default btn-xs dropdown-toggle glyphicon glyphicon-align-justify"
                t-att-id="object.getSuccinctProperty('cmis:objectId')"
                aria-label="More actions"
@@ -171,10 +187,14 @@
                title="More actions"
                aria-haspopup="true"
                aria-expanded="true">
-            </a>
+            </button>
             <ul class="dropdown-menu btn-block" t-att-aria-labelledby="object.getSuccinctProperty('cmis:objectId')">
                 <li t-if='canGetProperties'><a class='content-action-get-properties' href="#">View Details</a></li>
                 <li t-if='canUpdateProperties'><a class='content-action-rename' href="#">Rename</a></li>
+                <li t-if='!isFolder'><a class='content-action-copy' href="#"><i class="fa fa-copy"></i> Copy</a></li>
+                <li t-if='canMoveObject'><a class='content-action-cut' href="#"><i class="fa fa-cut"></i> Cut</a></li>
+                <li t-if='canCreateDocument &amp; object.parent.clipboardAction == "cut"'><a class='content-action-cut-paste' href="#"><i class="fa fa-paste"></i> Paste</a></li>
+                <li t-if='canCreateDocument &amp; object.parent.clipboardAction == "copy"'><a class='content-action-copy-paste' href="#"><i class="fa fa-paste"></i> Paste</a></li>
                 <li t-if='canSetContentStream and !canCheckIn'><a class='content-action-set-content-stream' href="#">Update</a></li>
                 <!-- li t-if='canGetAllVersions'><a class='content-action-get-all-versions' href="#">Check Versions</a></li -->
                 <li t-if='canCheckIn or canCancelCheckOut or canCheckOut' role="separator" class="divider"></li>

--- a/cmis_web_proxy_alf/controllers/alfresco.py
+++ b/cmis_web_proxy_alf/controllers/alfresco.py
@@ -33,7 +33,7 @@ class AlfrescoProxy(cmis.CmisProxy):
         '/<int:backend_id>'
         '/content/thumbnails/pdf/' +
         '<string:cmis_name>',
-        ], type='http', auth="user", csrf=False, methods=['GET'])
+    ], type='http', auth="user", csrf=False, methods=['GET'])
     @main.serialize_exception
     def get_thumnails(self, backend_id, cmis_name,
                       **kwargs):


### PR DESCRIPTION
- [X]  cmis_field: Prevent error in unique name computation
- [X]  cmis_field: Escape quote char "'" into query
This change fixes an error in the case when a folder with a single quote
into the name was creaed by the backend. 
- [X] cmis_web: Fixes an error in the case when a file with a single quote
into the name was dropped two times in the same folder. Into the second
drop, the logic in charge of processing duplication of content do a cmis
query to check if a document with the same name already exists. The
error occured into this query since the single quote was not escaped.
- [X] cmis_web: cut / copy / paste feature