### PR TITLE
[10.0][FIX] Refresh generates traceback

### DIFF
--- a/cmis_alf/models/cmis_backend.py
+++ b/cmis_alf/models/cmis_backend.py
@@ -4,6 +4,9 @@
 
 from odoo import fields, models
 
+_default_share_location = 'http://localhost:8080/share'
+_default_alfresco_api_location = 'http://localhost:8080/alfresco/s/api'
+
 
 class CmisBackend(models.Model):
     _inherit = 'cmis.backend'
@@ -12,11 +15,11 @@ class CmisBackend(models.Model):
     share_location = fields.Char(
         string='Alfresco Share Url',
         required=True,
-        default='http://localhost:8080/share'
+        default=_default_share_location
     )
 
     alfresco_api_location = fields.Char(
         string='Alfresco Api Url',
         required=True,
-        default='http://localhost:8080/alfresco/s/api'
+        default=_default_alfresco_api_location
     )

--- a/cmis_field/models/cmis_backend.py
+++ b/cmis_field/models/cmis_backend.py
@@ -7,6 +7,8 @@ from odoo.exceptions import UserError, ValidationError
 
 CMIS_NAME_INVALID_CHARS = r'\/:*?"<>|'
 CMIS_NAME_INVALID_CHARS_RX = '[' + re.escape(CMIS_NAME_INVALID_CHARS) + ']'
+_default_sanitize_replace_char = '_'
+_default_folder_name_conflict_handler = 'error'
 
 
 class CmisBackend(models.Model):
@@ -33,7 +35,7 @@ class CmisBackend(models.Model):
         'Replacement char',
         help='Character used as replacement of invalid characters found in'
              'the value to use as cmis:name by the sanitize method',
-        default='_')
+        default=_default_sanitize_replace_char)
     folder_name_conflict_handler = fields.Selection(
         selection=[
             ('error', _('Raise exception')),
@@ -41,7 +43,7 @@ class CmisBackend(models.Model):
         ],
         string='Strategy in case of duplicate',
         required=True,
-        default='error',
+        default=_default_folder_name_conflict_handler,
     )
 
     @api.model

--- a/cmis_web/static/src/js/form_widgets.js
+++ b/cmis_web/static/src/js/form_widgets.js
@@ -1306,6 +1306,16 @@ var CmisMixin = {
      *              reset - i.e. the current page will still be shown.
      */
     refresh_datatable: function(paging) {
+        var self = this;
+        var rows = this.$datatable.find('tr[id]');
+        var to_show = [];
+        _.each(rows, function(row){
+            var r = self.datatable.row(row);
+            if ( r.child.isShown() ) {
+                self.display_row_details(r);
+                to_show.push(r);
+            }
+        });
         this.datatable.draw(paging || 'page');
     },
 


### PR DESCRIPTION
Planio refs #36058
---FIX---
The traceback comes from the cmis library when we try to update the details of a document that has changed on an external tool. 
To avoid this issue: Close the details views before Refresh. 