### PR TITLE
[16.0] [FIX] cmis_web: save record before creating root folder

### DIFF
--- a/cmis_web/static/src/cmis_folder/cmis_folder.js
+++ b/cmis_web/static/src/cmis_folder/cmis_folder.js
@@ -157,6 +157,7 @@ export class CmisFolderField extends Component {
     }
 
     async createRootFolder() {
+        await this.props.record.save();
         if (!this.props.record.resId) {
             this.dialogService.add(WarningDialog, {
                 title: "CMIS Error",


### PR DESCRIPTION
This fix prevents the loss of the ongoing modifications on the record.