### PR TITLE
[FIX] cmis_web: save record before creating root folder

### DIFF
--- a/cmis_web/static/src/cmis_folder/cmis_folder.js
+++ b/cmis_web/static/src/cmis_folder/cmis_folder.js
@@ -164,6 +164,7 @@ export class CmisFolderField extends Component {
             });
             return;
         }
+        this.props.record.save()
         const cmisFolderValue = await this.rpc("/web/cmis/field/create_value", {
             model_name: this.props.record.resModel,
             res_id: this.props.record.data.id,


### PR DESCRIPTION
Before this PR, when the user modifies the record and then creates folder in DMS, Odoo doesn't save the modifications. Hence the user has lost all his changes.